### PR TITLE
Implement modular Express API for DnD backend

### DIFF
--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -1,0 +1,192 @@
+import {
+  sequelize,
+  Campaign,
+  CampaignRole,
+  User,
+  World,
+  UserCampaignRole,
+  Character
+} from '../models/index.js';
+
+const campaignIncludes = [
+  { association: 'roles' },
+  { association: 'creator' },
+  { association: 'world' },
+  { model: Character, as: 'characters', through: { attributes: [] } }
+];
+
+const ensureCampaignExists = async (id, res) => {
+  const campaign = await Campaign.findByPk(id);
+  if (!campaign) {
+    res.status(404).json({ success: false, message: 'Campaign not found' });
+    return null;
+  }
+  return campaign;
+};
+
+export const getCampaigns = async (req, res) => {
+  try {
+    const campaigns = await Campaign.findAll({ include: campaignIncludes });
+    res.json({ success: true, data: campaigns });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCampaignById = async (req, res) => {
+  try {
+    const campaign = await Campaign.findByPk(req.params.id, { include: campaignIncludes });
+    if (!campaign) {
+      return res.status(404).json({ success: false, message: 'Campaign not found' });
+    }
+    res.json({ success: true, data: campaign });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createCampaign = async (req, res) => {
+  const transaction = await sequelize.transaction();
+  try {
+    const { name, description, world_id, created_by } = req.body;
+    if (!name) {
+      await transaction.rollback();
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    if (!created_by) {
+      await transaction.rollback();
+      return res.status(400).json({ success: false, message: 'created_by is required to assign Dungeon Master' });
+    }
+
+    const creator = await User.findByPk(created_by, { transaction });
+    if (!creator) {
+      await transaction.rollback();
+      return res.status(404).json({ success: false, message: 'Creator not found' });
+    }
+
+    if (world_id) {
+      const world = await World.findByPk(world_id, { transaction });
+      if (!world) {
+        await transaction.rollback();
+        return res.status(404).json({ success: false, message: 'World not found' });
+      }
+    }
+
+    const campaign = await Campaign.create({ name, description, world_id, created_by }, { transaction });
+
+    const roles = await CampaignRole.bulkCreate([
+      { name: 'Dungeon Master', description: 'Campaign overseer', campaign_id: campaign.id },
+      { name: 'Player', description: 'Player participant', campaign_id: campaign.id },
+      { name: 'Viewer', description: 'View-only participant', campaign_id: campaign.id }
+    ], { transaction, returning: true });
+
+    const dmRole = roles.find((role) => role.name === 'Dungeon Master');
+    if (dmRole) {
+      await UserCampaignRole.create({
+        user_id: created_by,
+        campaign_id: campaign.id,
+        campaign_role_id: dmRole.id
+      }, { transaction });
+    }
+
+    await transaction.commit();
+
+    const created = await Campaign.findByPk(campaign.id, { include: campaignIncludes });
+    res.status(201).json({ success: true, data: created, message: 'Campaign created' });
+  } catch (err) {
+    await transaction.rollback();
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateCampaign = async (req, res) => {
+  try {
+    const campaign = await ensureCampaignExists(req.params.id, res);
+    if (!campaign) return;
+
+    const { name, description, world_id } = req.body;
+    if (typeof name === 'undefined' && typeof description === 'undefined' && typeof world_id === 'undefined') {
+      return res.status(400).json({ success: false, message: 'Nothing to update' });
+    }
+
+    if (typeof world_id !== 'undefined') {
+      if (world_id === null) {
+        campaign.world_id = null;
+      } else {
+        const world = await World.findByPk(world_id);
+        if (!world) {
+          return res.status(404).json({ success: false, message: 'World not found' });
+        }
+        campaign.world_id = world_id;
+      }
+    }
+    if (typeof name !== 'undefined') campaign.name = name;
+    if (typeof description !== 'undefined') campaign.description = description;
+
+    await campaign.save();
+    const refreshed = await Campaign.findByPk(campaign.id, { include: campaignIncludes });
+    res.json({ success: true, data: refreshed, message: 'Campaign updated' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteCampaign = async (req, res) => {
+  try {
+    const campaign = await ensureCampaignExists(req.params.id, res);
+    if (!campaign) return;
+
+    await campaign.destroy();
+    res.json({ success: true, data: campaign, message: 'Campaign deleted' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCampaignRoles = async (req, res) => {
+  try {
+    const campaign = await ensureCampaignExists(req.params.id, res);
+    if (!campaign) return;
+
+    const roles = await CampaignRole.findAll({ where: { campaign_id: campaign.id } });
+    res.json({ success: true, data: roles });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCampaignUsers = async (req, res) => {
+  try {
+    const campaign = await ensureCampaignExists(req.params.id, res);
+    if (!campaign) return;
+
+    const assignments = await UserCampaignRole.findAll({
+      where: { campaign_id: campaign.id },
+      include: [
+        { association: 'user' },
+        { association: 'role' }
+      ]
+    });
+
+    res.json({ success: true, data: assignments });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCampaignCharacters = async (req, res) => {
+  try {
+    const campaign = await Campaign.findByPk(req.params.id, {
+      include: [{ model: Character, as: 'characters', through: { attributes: [] } }]
+    });
+
+    if (!campaign) {
+      return res.status(404).json({ success: false, message: 'Campaign not found' });
+    }
+
+    res.json({ success: true, data: campaign.characters });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/campaignRoleController.js
+++ b/backend/src/controllers/campaignRoleController.js
@@ -1,0 +1,77 @@
+import { CampaignRole, Campaign } from '../models/index.js';
+
+export const getCampaignRoles = async (req, res) => {
+  try {
+    const roles = await CampaignRole.findAll({ include: [{ association: 'campaign' }] });
+    res.json({ success: true, data: roles });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCampaignRoleById = async (req, res) => {
+  try {
+    const role = await CampaignRole.findByPk(req.params.id, { include: [{ association: 'campaign' }] });
+    if (!role) {
+      return res.status(404).json({ success: false, message: 'Campaign role not found' });
+    }
+    res.json({ success: true, data: role });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createCampaignRole = async (req, res) => {
+  try {
+    const { name, description, campaign_id } = req.body;
+    if (!name || !campaign_id) {
+      return res.status(400).json({ success: false, message: 'name and campaign_id are required' });
+    }
+
+    const campaign = await Campaign.findByPk(campaign_id);
+    if (!campaign) {
+      return res.status(404).json({ success: false, message: 'Campaign not found' });
+    }
+
+    const role = await CampaignRole.create({ name, description, campaign_id });
+    res.status(201).json({ success: true, data: role, message: 'Campaign role created' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateCampaignRole = async (req, res) => {
+  try {
+    const role = await CampaignRole.findByPk(req.params.id);
+    if (!role) {
+      return res.status(404).json({ success: false, message: 'Campaign role not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name === 'undefined' && typeof description === 'undefined') {
+      return res.status(400).json({ success: false, message: 'Nothing to update' });
+    }
+
+    if (typeof name !== 'undefined') role.name = name;
+    if (typeof description !== 'undefined') role.description = description;
+
+    await role.save();
+    res.json({ success: true, data: role, message: 'Campaign role updated' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteCampaignRole = async (req, res) => {
+  try {
+    const role = await CampaignRole.findByPk(req.params.id);
+    if (!role) {
+      return res.status(404).json({ success: false, message: 'Campaign role not found' });
+    }
+
+    await role.destroy();
+    res.json({ success: true, data: role, message: 'Campaign role deleted' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/characterCampaignController.js
+++ b/backend/src/controllers/characterCampaignController.js
@@ -1,0 +1,60 @@
+import { CharacterCampaign, Character, Campaign } from '../models/index.js';
+
+export const getCharacterCampaigns = async (req, res) => {
+  try {
+    const links = await CharacterCampaign.findAll({
+      include: [
+        { association: 'character' },
+        { association: 'campaign' }
+      ]
+    });
+    res.json({ success: true, data: links });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createCharacterCampaign = async (req, res) => {
+  try {
+    const { character_id, campaign_id } = req.body;
+    if (!character_id || !campaign_id) {
+      return res.status(400).json({ success: false, message: 'character_id and campaign_id are required' });
+    }
+
+    const [character, campaign] = await Promise.all([
+      Character.findByPk(character_id),
+      Campaign.findByPk(campaign_id)
+    ]);
+
+    if (!character || !campaign) {
+      return res.status(404).json({ success: false, message: 'Character or campaign not found' });
+    }
+
+    const [link, created] = await CharacterCampaign.findOrCreate({
+      where: { character_id, campaign_id },
+      defaults: { character_id, campaign_id }
+    });
+
+    res.status(created ? 201 : 200).json({
+      success: true,
+      data: link,
+      message: created ? 'Character linked to campaign' : 'Link already exists'
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteCharacterCampaign = async (req, res) => {
+  try {
+    const link = await CharacterCampaign.findByPk(req.params.id);
+    if (!link) {
+      return res.status(404).json({ success: false, message: 'Link not found' });
+    }
+
+    await link.destroy();
+    res.json({ success: true, data: link, message: 'Link removed' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/characterController.js
+++ b/backend/src/controllers/characterController.js
@@ -1,0 +1,137 @@
+import {
+  Character,
+  User,
+  Campaign,
+  CharacterCampaign
+} from '../models/index.js';
+
+const characterIncludes = [
+  { model: User, as: 'owner' },
+  { model: Campaign, as: 'campaigns', through: { attributes: [] } }
+];
+
+const ensureCharacterExists = async (id, res) => {
+  const character = await Character.findByPk(id);
+  if (!character) {
+    res.status(404).json({ success: false, message: 'Character not found' });
+    return null;
+  }
+  return character;
+};
+
+export const getCharacters = async (req, res) => {
+  try {
+    const characters = await Character.findAll({ include: characterIncludes });
+    res.json({ success: true, data: characters });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getCharacterById = async (req, res) => {
+  try {
+    const character = await Character.findByPk(req.params.id, { include: characterIncludes });
+    if (!character) {
+      return res.status(404).json({ success: false, message: 'Character not found' });
+    }
+    res.json({ success: true, data: character });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createCharacter = async (req, res) => {
+  try {
+    const { name, user_id, description, level, class: charClass, stats_json, active } = req.body;
+    if (!name || !user_id) {
+      return res.status(400).json({ success: false, message: 'name and user_id are required' });
+    }
+
+    const user = await User.findByPk(user_id);
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+
+    const character = await Character.create({
+      name,
+      user_id,
+      description,
+      level,
+      class: charClass,
+      stats_json,
+      active
+    });
+
+    const created = await Character.findByPk(character.id, { include: characterIncludes });
+    res.status(201).json({ success: true, data: created, message: 'Character created' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateCharacter = async (req, res) => {
+  try {
+    const character = await ensureCharacterExists(req.params.id, res);
+    if (!character) return;
+
+    const { name, description, level, class: charClass, stats_json, active } = req.body;
+    if (typeof name === 'undefined' && typeof description === 'undefined' && typeof level === 'undefined' && typeof charClass === 'undefined' && typeof stats_json === 'undefined' && typeof active === 'undefined') {
+      return res.status(400).json({ success: false, message: 'Nothing to update' });
+    }
+
+    if (typeof name !== 'undefined') character.name = name;
+    if (typeof description !== 'undefined') character.description = description;
+    if (typeof level !== 'undefined') character.level = level;
+    if (typeof charClass !== 'undefined') character.set('class', charClass);
+    if (typeof stats_json !== 'undefined') character.stats_json = stats_json;
+    if (typeof active !== 'undefined') character.active = active;
+
+    await character.save();
+    const updated = await Character.findByPk(character.id, { include: characterIncludes });
+    res.json({ success: true, data: updated, message: 'Character updated' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteCharacter = async (req, res) => {
+  try {
+    const character = await ensureCharacterExists(req.params.id, res);
+    if (!character) return;
+
+    await character.destroy();
+    res.json({ success: true, data: character, message: 'Character deleted' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const assignCharacterToCampaign = async (req, res) => {
+  try {
+    const character = await ensureCharacterExists(req.params.id, res);
+    if (!character) return;
+
+    const { campaignId } = req.body;
+    if (!campaignId) {
+      return res.status(400).json({ success: false, message: 'campaignId is required' });
+    }
+
+    const campaign = await Campaign.findByPk(campaignId);
+    if (!campaign) {
+      return res.status(404).json({ success: false, message: 'Campaign not found' });
+    }
+
+    const [link, created] = await CharacterCampaign.findOrCreate({
+      where: { character_id: character.id, campaign_id: campaign.id },
+      defaults: { character_id: character.id, campaign_id: campaign.id }
+    });
+
+    res.status(created ? 201 : 200).json({
+      success: true,
+      data: link,
+      message: created ? 'Character assigned to campaign' : 'Character already in campaign'
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/systemRoleController.js
+++ b/backend/src/controllers/systemRoleController.js
@@ -1,0 +1,65 @@
+import { SystemRole } from '../models/index.js';
+
+export const getSystemRoles = async (req, res) => {
+  try {
+    const roles = await SystemRole.findAll();
+    res.json({ success: true, data: roles });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createSystemRole = async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    const existing = await SystemRole.findOne({ where: { name } });
+    if (existing) {
+      return res.status(409).json({ success: false, message: 'Role with this name already exists' });
+    }
+
+    const role = await SystemRole.create({ name, description });
+    res.status(201).json({ success: true, data: role, message: 'System role created' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateSystemRole = async (req, res) => {
+  try {
+    const role = await SystemRole.findByPk(req.params.id);
+    if (!role) {
+      return res.status(404).json({ success: false, message: 'System role not found' });
+    }
+
+    const { name, description } = req.body;
+    if (!name && !description) {
+      return res.status(400).json({ success: false, message: 'Nothing to update' });
+    }
+
+    if (name) role.name = name;
+    if (description) role.description = description;
+    await role.save();
+
+    res.json({ success: true, data: role, message: 'System role updated' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteSystemRole = async (req, res) => {
+  try {
+    const role = await SystemRole.findByPk(req.params.id);
+    if (!role) {
+      return res.status(404).json({ success: false, message: 'System role not found' });
+    }
+
+    await role.destroy();
+    res.json({ success: true, data: role, message: 'System role deleted' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/userCampaignRoleController.js
+++ b/backend/src/controllers/userCampaignRoleController.js
@@ -1,0 +1,66 @@
+import { UserCampaignRole, User, Campaign, CampaignRole } from '../models/index.js';
+
+export const getUserCampaignRoles = async (req, res) => {
+  try {
+    const assignments = await UserCampaignRole.findAll({
+      include: [
+        { association: 'user' },
+        { association: 'campaign' },
+        { association: 'role' }
+      ]
+    });
+    res.json({ success: true, data: assignments });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createUserCampaignRole = async (req, res) => {
+  try {
+    const { user_id, campaign_id, campaign_role_id } = req.body;
+    if (!user_id || !campaign_id || !campaign_role_id) {
+      return res.status(400).json({ success: false, message: 'user_id, campaign_id and campaign_role_id are required' });
+    }
+
+    const [user, campaign, role] = await Promise.all([
+      User.findByPk(user_id),
+      Campaign.findByPk(campaign_id),
+      CampaignRole.findByPk(campaign_role_id)
+    ]);
+
+    if (!user || !campaign || !role) {
+      return res.status(404).json({ success: false, message: 'User, campaign or role not found' });
+    }
+
+    if (role.campaign_id !== campaign.id) {
+      return res.status(400).json({ success: false, message: 'Role does not belong to the specified campaign' });
+    }
+
+    const [assignment, created] = await UserCampaignRole.findOrCreate({
+      where: { user_id, campaign_id, campaign_role_id },
+      defaults: { user_id, campaign_id, campaign_role_id }
+    });
+
+    res.status(created ? 201 : 200).json({
+      success: true,
+      data: assignment,
+      message: created ? 'Assignment created' : 'Assignment already exists'
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteUserCampaignRole = async (req, res) => {
+  try {
+    const assignment = await UserCampaignRole.findByPk(req.params.id);
+    if (!assignment) {
+      return res.status(404).json({ success: false, message: 'Assignment not found' });
+    }
+
+    await assignment.destroy();
+    res.json({ success: true, data: assignment, message: 'Assignment removed' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,0 +1,188 @@
+import { Op } from 'sequelize';
+import {
+  User,
+  Campaign,
+  CampaignRole,
+  Character,
+  SystemRole,
+  UserSystemRole,
+  UserCampaignRole
+} from '../models/index.js';
+
+const userIncludes = [
+  { model: Character, as: 'characters', include: [{ model: Campaign, as: 'campaigns', through: { attributes: [] } }] },
+  { model: SystemRole, as: 'systemRoles', through: { attributes: [] } }
+];
+
+const ensureUserExists = async (id, res) => {
+  const user = await User.findByPk(id);
+  if (!user) {
+    res.status(404).json({ success: false, message: 'User not found' });
+    return null;
+  }
+  return user;
+};
+
+export const getUsers = async (req, res) => {
+  try {
+    const users = await User.findAll({ include: userIncludes });
+    res.json({ success: true, data: users });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getUserById = async (req, res) => {
+  try {
+    const user = await User.findByPk(req.params.id, { include: userIncludes });
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+    res.json({ success: true, data: user });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createUser = async (req, res) => {
+  try {
+    const { username, email, password_hash } = req.body;
+    if (!username || !email || !password_hash) {
+      return res.status(400).json({ success: false, message: 'username, email and password_hash are required' });
+    }
+
+    const existing = await User.findOne({ where: { [Op.or]: [{ username }, { email }] } });
+    if (existing) {
+      return res.status(409).json({ success: false, message: 'User with provided username or email already exists' });
+    }
+
+    const user = await User.create({ username, email, password_hash });
+    res.status(201).json({ success: true, data: user, message: 'User created successfully' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateUser = async (req, res) => {
+  try {
+    const user = await ensureUserExists(req.params.id, res);
+    if (!user) return;
+
+    const { username, email, password_hash, active } = req.body;
+    if (typeof username === 'undefined' && typeof email === 'undefined' && typeof password_hash === 'undefined' && typeof active === 'undefined') {
+      return res.status(400).json({ success: false, message: 'At least one field must be provided for update' });
+    }
+
+    if (typeof username !== 'undefined') user.username = username;
+    if (typeof email !== 'undefined') user.email = email;
+    if (typeof password_hash !== 'undefined') user.password_hash = password_hash;
+    if (typeof active !== 'undefined') user.active = active;
+
+    await user.save();
+    const reloaded = await User.findByPk(user.id, { include: userIncludes });
+    res.json({ success: true, data: reloaded, message: 'User updated successfully' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteUser = async (req, res) => {
+  try {
+    const user = await ensureUserExists(req.params.id, res);
+    if (!user) return;
+
+    user.active = false;
+    await user.save();
+    res.json({ success: true, data: user, message: 'User deactivated successfully' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getUserCampaigns = async (req, res) => {
+  try {
+    const user = await ensureUserExists(req.params.id, res);
+    if (!user) return;
+
+    const assignments = await UserCampaignRole.findAll({
+      where: { user_id: user.id },
+      include: [
+        {
+          model: Campaign,
+          as: 'campaign',
+          include: [
+            { model: CampaignRole, as: 'roles' },
+            { model: Character, as: 'characters', through: { attributes: [] } }
+          ]
+        },
+        { model: CampaignRole, as: 'role' }
+      ]
+    });
+
+    res.json({ success: true, data: assignments });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getUserCharacters = async (req, res) => {
+  try {
+    const user = await ensureUserExists(req.params.id, res);
+    if (!user) return;
+
+    const characters = await Character.findAll({
+      where: { user_id: user.id },
+      include: [{ model: Campaign, as: 'campaigns', through: { attributes: [] } }]
+    });
+
+    res.json({ success: true, data: characters });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getUserSystemRoles = async (req, res) => {
+  try {
+    const user = await User.findByPk(req.params.id, {
+      include: [{ model: SystemRole, as: 'systemRoles', through: { attributes: [] } }]
+    });
+
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+
+    res.json({ success: true, data: user.systemRoles });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const assignSystemRoleToUser = async (req, res) => {
+  try {
+    const { roleId } = req.body;
+    if (!roleId) {
+      return res.status(400).json({ success: false, message: 'roleId is required' });
+    }
+
+    const user = await ensureUserExists(req.params.id, res);
+    if (!user) return;
+
+    const systemRole = await SystemRole.findByPk(roleId);
+    if (!systemRole) {
+      return res.status(404).json({ success: false, message: 'System role not found' });
+    }
+
+    const [assignment, created] = await UserSystemRole.findOrCreate({
+      where: { user_id: user.id, system_role_id: systemRole.id },
+      defaults: { user_id: user.id, system_role_id: systemRole.id }
+    });
+
+    res.status(created ? 201 : 200).json({
+      success: true,
+      data: assignment,
+      message: created ? 'Role assigned to user' : 'User already has this role'
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/controllers/worldController.js
+++ b/backend/src/controllers/worldController.js
@@ -1,0 +1,100 @@
+import { World, Campaign, User } from '../models/index.js';
+
+export const getWorlds = async (req, res) => {
+  try {
+    const worlds = await World.findAll({ include: [{ model: Campaign, as: 'campaigns' }] });
+    res.json({ success: true, data: worlds });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getWorldById = async (req, res) => {
+  try {
+    const world = await World.findByPk(req.params.id, { include: [{ model: Campaign, as: 'campaigns' }] });
+    if (!world) {
+      return res.status(404).json({ success: false, message: 'World not found' });
+    }
+    res.json({ success: true, data: world });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const createWorld = async (req, res) => {
+  try {
+    const { name, description, created_by } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    if (created_by) {
+      const creator = await User.findByPk(created_by);
+      if (!creator) {
+        return res.status(404).json({ success: false, message: 'Creator not found' });
+      }
+    }
+
+    const world = await World.create({ name, description, created_by });
+    res.status(201).json({ success: true, data: world, message: 'World created' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const updateWorld = async (req, res) => {
+  try {
+    const world = await World.findByPk(req.params.id);
+    if (!world) {
+      return res.status(404).json({ success: false, message: 'World not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name === 'undefined' && typeof description === 'undefined') {
+      return res.status(400).json({ success: false, message: 'Nothing to update' });
+    }
+
+    if (typeof name !== 'undefined') world.name = name;
+    if (typeof description !== 'undefined') world.description = description;
+
+    await world.save();
+    res.json({ success: true, data: world, message: 'World updated' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const deleteWorld = async (req, res) => {
+  try {
+    const world = await World.findByPk(req.params.id);
+    if (!world) {
+      return res.status(404).json({ success: false, message: 'World not found' });
+    }
+
+    await world.destroy();
+    res.json({ success: true, data: world, message: 'World deleted' });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};
+
+export const getWorldCampaigns = async (req, res) => {
+  try {
+    const world = await World.findByPk(req.params.id);
+    if (!world) {
+      return res.status(404).json({ success: false, message: 'World not found' });
+    }
+
+    const campaigns = await Campaign.findAll({
+      where: { world_id: world.id },
+      include: [
+        { association: 'roles' },
+        { association: 'creator' }
+      ]
+    });
+
+    res.json({ success: true, data: campaigns });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+};

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -1,13 +1,19 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
-import World from './World.js';
-import User from './User.js';
+
 export default class Campaign extends Model {}
+
 Campaign.init({
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
-  name: DataTypes.STRING,
-  description: DataTypes.TEXT
-}, { sequelize, modelName: 'Campaign', tableName: 'campaigns', timestamps: true });
-
-Campaign.belongsTo(World, { foreignKey: 'world_id' });
-Campaign.belongsTo(User, { as: 'creator', foreignKey: 'created_by' });
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_by: { type: DataTypes.UUID },
+  world_id: { type: DataTypes.UUID }
+}, {
+  sequelize,
+  modelName: 'Campaign',
+  tableName: 'campaigns',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});

--- a/backend/src/models/CampaignRole.js
+++ b/backend/src/models/CampaignRole.js
@@ -1,11 +1,11 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
-import Campaign from './Campaign.js';
+
 export default class CampaignRole extends Model {}
+
 CampaignRole.init({
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
-  name: DataTypes.STRING,
-  description: DataTypes.STRING
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.STRING,
+  campaign_id: { type: DataTypes.UUID }
 }, { sequelize, modelName: 'CampaignRole', tableName: 'campaign_roles', timestamps: false });
-
-CampaignRole.belongsTo(Campaign, { foreignKey: 'campaign_id' });

--- a/backend/src/models/Character.js
+++ b/backend/src/models/Character.js
@@ -1,15 +1,22 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
-import User from './User.js';
+
 export default class Character extends Model {}
+
 Character.init({
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
-  name: DataTypes.STRING,
+  name: { type: DataTypes.STRING, allowNull: false },
   description: DataTypes.TEXT,
   level: { type: DataTypes.INTEGER, defaultValue: 1 },
   class: DataTypes.STRING,
   stats_json: { type: DataTypes.JSONB, defaultValue: {} },
+  user_id: { type: DataTypes.UUID },
   active: { type: DataTypes.BOOLEAN, defaultValue: true }
-}, { sequelize, modelName: 'Character', tableName: 'characters', timestamps: true });
-
-Character.belongsTo(User, { foreignKey: 'user_id' });
+}, {
+  sequelize,
+  modelName: 'Character',
+  tableName: 'characters',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});

--- a/backend/src/models/CharacterCampaign.js
+++ b/backend/src/models/CharacterCampaign.js
@@ -1,6 +1,11 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
+
 export default class CharacterCampaign extends Model {}
+
 CharacterCampaign.init({
-  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true }
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  character_id: { type: DataTypes.UUID },
+  campaign_id: { type: DataTypes.UUID },
+  joined_at: { type: DataTypes.DATE }
 }, { sequelize, modelName: 'CharacterCampaign', tableName: 'character_campaigns', timestamps: false });

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -2,10 +2,18 @@ import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
 
 export default class User extends Model {}
+
 User.init({
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
   username: { type: DataTypes.STRING, allowNull: false, unique: true },
   email: { type: DataTypes.STRING, allowNull: false, unique: true },
   password_hash: { type: DataTypes.STRING, allowNull: false },
   active: { type: DataTypes.BOOLEAN, defaultValue: true }
-}, { sequelize, modelName: 'User', tableName: 'users', timestamps: true });
+}, {
+  sequelize,
+  modelName: 'User',
+  tableName: 'users',
+  timestamps: true,
+  createdAt: 'created_at',
+  updatedAt: 'updated_at'
+});

--- a/backend/src/models/UserCampaignRole.js
+++ b/backend/src/models/UserCampaignRole.js
@@ -1,6 +1,12 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
+
 export default class UserCampaignRole extends Model {}
+
 UserCampaignRole.init({
-  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true }
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  user_id: { type: DataTypes.UUID },
+  campaign_id: { type: DataTypes.UUID },
+  campaign_role_id: { type: DataTypes.UUID },
+  joined_at: { type: DataTypes.DATE }
 }, { sequelize, modelName: 'UserCampaignRole', tableName: 'user_campaign_roles', timestamps: false });

--- a/backend/src/models/UserSystemRole.js
+++ b/backend/src/models/UserSystemRole.js
@@ -1,11 +1,11 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
-import User from './User.js';
-import SystemRole from './SystemRole.js';
-export default class UserSystemRole extends Model {}
-UserSystemRole.init({
-  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true }
-}, { sequelize, modelName: 'UserSystemRole', tableName: 'user_system_roles', timestamps: false });
 
-User.belongsToMany(SystemRole, { through: UserSystemRole, foreignKey: 'user_id' });
-SystemRole.belongsToMany(User, { through: UserSystemRole, foreignKey: 'system_role_id' });
+export default class UserSystemRole extends Model {}
+
+UserSystemRole.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  user_id: { type: DataTypes.UUID },
+  system_role_id: { type: DataTypes.UUID },
+  assigned_at: { type: DataTypes.DATE }
+}, { sequelize, modelName: 'UserSystemRole', tableName: 'user_system_roles', timestamps: false });

--- a/backend/src/models/World.js
+++ b/backend/src/models/World.js
@@ -1,8 +1,12 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../config/db.js';
+
 export default class World extends Model {}
+
 World.init({
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
-  name: DataTypes.STRING,
-  description: DataTypes.TEXT
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_by: { type: DataTypes.UUID },
+  created_at: { type: DataTypes.DATE }
 }, { sequelize, modelName: 'World', tableName: 'worlds', timestamps: false });

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -9,9 +9,92 @@ import UserCampaignRole from './UserCampaignRole.js';
 import Character from './Character.js';
 import CharacterCampaign from './CharacterCampaign.js';
 
+User.hasMany(Character, { as: 'characters', foreignKey: 'user_id' });
+Character.belongsTo(User, { as: 'owner', foreignKey: 'user_id' });
+
+World.hasMany(Campaign, { as: 'campaigns', foreignKey: 'world_id' });
+Campaign.belongsTo(World, { as: 'world', foreignKey: 'world_id' });
+
+User.hasMany(Campaign, { as: 'createdCampaigns', foreignKey: 'created_by' });
+Campaign.belongsTo(User, { as: 'creator', foreignKey: 'created_by' });
+
+User.belongsToMany(SystemRole, {
+  through: UserSystemRole,
+  as: 'systemRoles',
+  foreignKey: 'user_id',
+  otherKey: 'system_role_id'
+});
+SystemRole.belongsToMany(User, {
+  through: UserSystemRole,
+  as: 'users',
+  foreignKey: 'system_role_id',
+  otherKey: 'user_id'
+});
+UserSystemRole.belongsTo(User, { as: 'user', foreignKey: 'user_id' });
+UserSystemRole.belongsTo(SystemRole, { as: 'systemRole', foreignKey: 'system_role_id' });
+User.hasMany(UserSystemRole, { as: 'userSystemRoles', foreignKey: 'user_id' });
+SystemRole.hasMany(UserSystemRole, { as: 'userSystemRoles', foreignKey: 'system_role_id' });
+
+Campaign.hasMany(CampaignRole, { as: 'roles', foreignKey: 'campaign_id' });
+CampaignRole.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+
+User.belongsToMany(Campaign, {
+  through: UserCampaignRole,
+  as: 'campaigns',
+  foreignKey: 'user_id',
+  otherKey: 'campaign_id'
+});
+Campaign.belongsToMany(User, {
+  through: UserCampaignRole,
+  as: 'users',
+  foreignKey: 'campaign_id',
+  otherKey: 'user_id'
+});
+User.belongsToMany(CampaignRole, {
+  through: UserCampaignRole,
+  as: 'campaignRoles',
+  foreignKey: 'user_id',
+  otherKey: 'campaign_role_id'
+});
+CampaignRole.belongsToMany(User, {
+  through: UserCampaignRole,
+  as: 'users',
+  foreignKey: 'campaign_role_id',
+  otherKey: 'user_id'
+});
+UserCampaignRole.belongsTo(User, { as: 'user', foreignKey: 'user_id' });
+UserCampaignRole.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+UserCampaignRole.belongsTo(CampaignRole, { as: 'role', foreignKey: 'campaign_role_id' });
+User.hasMany(UserCampaignRole, { as: 'userCampaignRoles', foreignKey: 'user_id' });
+Campaign.hasMany(UserCampaignRole, { as: 'userCampaignRoles', foreignKey: 'campaign_id' });
+CampaignRole.hasMany(UserCampaignRole, { as: 'userCampaignRoles', foreignKey: 'campaign_role_id' });
+
+Character.belongsToMany(Campaign, {
+  through: CharacterCampaign,
+  as: 'campaigns',
+  foreignKey: 'character_id',
+  otherKey: 'campaign_id'
+});
+Campaign.belongsToMany(Character, {
+  through: CharacterCampaign,
+  as: 'characters',
+  foreignKey: 'campaign_id',
+  otherKey: 'character_id'
+});
+CharacterCampaign.belongsTo(Character, { as: 'character', foreignKey: 'character_id' });
+CharacterCampaign.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+Character.hasMany(CharacterCampaign, { as: 'characterCampaigns', foreignKey: 'character_id' });
+Campaign.hasMany(CharacterCampaign, { as: 'characterCampaigns', foreignKey: 'campaign_id' });
+
 export {
   sequelize,
-  User, SystemRole, UserSystemRole,
-  World, Campaign, CampaignRole, UserCampaignRole,
-  Character, CharacterCampaign
+  User,
+  SystemRole,
+  UserSystemRole,
+  World,
+  Campaign,
+  CampaignRole,
+  UserCampaignRole,
+  Character,
+  CharacterCampaign
 };

--- a/backend/src/routes/campaignRoleRoutes.js
+++ b/backend/src/routes/campaignRoleRoutes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  getCampaignRoles,
+  getCampaignRoleById,
+  createCampaignRole,
+  updateCampaignRole,
+  deleteCampaignRole
+} from '../controllers/campaignRoleController.js';
+
+const router = Router();
+
+router.get('/', getCampaignRoles);
+router.get('/:id', getCampaignRoleById);
+router.post('/', createCampaignRole);
+router.put('/:id', updateCampaignRole);
+router.delete('/:id', deleteCampaignRole);
+
+export default router;

--- a/backend/src/routes/campaignRoutes.js
+++ b/backend/src/routes/campaignRoutes.js
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import {
+  getCampaigns,
+  getCampaignById,
+  createCampaign,
+  updateCampaign,
+  deleteCampaign,
+  getCampaignRoles,
+  getCampaignUsers,
+  getCampaignCharacters
+} from '../controllers/campaignController.js';
+
+const router = Router();
+
+router.get('/', getCampaigns);
+router.get('/:id', getCampaignById);
+router.post('/', createCampaign);
+router.put('/:id', updateCampaign);
+router.delete('/:id', deleteCampaign);
+router.get('/:id/roles', getCampaignRoles);
+router.get('/:id/users', getCampaignUsers);
+router.get('/:id/characters', getCampaignCharacters);
+
+export default router;

--- a/backend/src/routes/characterCampaignRoutes.js
+++ b/backend/src/routes/characterCampaignRoutes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  getCharacterCampaigns,
+  createCharacterCampaign,
+  deleteCharacterCampaign
+} from '../controllers/characterCampaignController.js';
+
+const router = Router();
+
+router.get('/', getCharacterCampaigns);
+router.post('/', createCharacterCampaign);
+router.delete('/:id', deleteCharacterCampaign);
+
+export default router;

--- a/backend/src/routes/characterRoutes.js
+++ b/backend/src/routes/characterRoutes.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import {
+  getCharacters,
+  getCharacterById,
+  createCharacter,
+  updateCharacter,
+  deleteCharacter,
+  assignCharacterToCampaign
+} from '../controllers/characterController.js';
+
+const router = Router();
+
+router.get('/', getCharacters);
+router.get('/:id', getCharacterById);
+router.post('/', createCharacter);
+router.put('/:id', updateCharacter);
+router.delete('/:id', deleteCharacter);
+router.post('/:id/campaigns', assignCharacterToCampaign);
+
+export default router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import userRoutes from './userRoutes.js';
+import systemRoleRoutes from './systemRoleRoutes.js';
+import worldRoutes from './worldRoutes.js';
+import campaignRoutes from './campaignRoutes.js';
+import campaignRoleRoutes from './campaignRoleRoutes.js';
+import userCampaignRoleRoutes from './userCampaignRoleRoutes.js';
+import characterRoutes from './characterRoutes.js';
+import characterCampaignRoutes from './characterCampaignRoutes.js';
+
+const router = Router();
+
+router.use('/users', userRoutes);
+router.use('/system-roles', systemRoleRoutes);
+router.use('/worlds', worldRoutes);
+router.use('/campaigns', campaignRoutes);
+router.use('/campaign-roles', campaignRoleRoutes);
+router.use('/user-campaign-roles', userCampaignRoleRoutes);
+router.use('/characters', characterRoutes);
+router.use('/character-campaigns', characterCampaignRoutes);
+
+export default router;

--- a/backend/src/routes/systemRoleRoutes.js
+++ b/backend/src/routes/systemRoleRoutes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import {
+  getSystemRoles,
+  createSystemRole,
+  updateSystemRole,
+  deleteSystemRole
+} from '../controllers/systemRoleController.js';
+
+const router = Router();
+
+router.get('/', getSystemRoles);
+router.post('/', createSystemRole);
+router.put('/:id', updateSystemRole);
+router.delete('/:id', deleteSystemRole);
+
+export default router;

--- a/backend/src/routes/userCampaignRoleRoutes.js
+++ b/backend/src/routes/userCampaignRoleRoutes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  getUserCampaignRoles,
+  createUserCampaignRole,
+  deleteUserCampaignRole
+} from '../controllers/userCampaignRoleController.js';
+
+const router = Router();
+
+router.get('/', getUserCampaignRoles);
+router.post('/', createUserCampaignRole);
+router.delete('/:id', deleteUserCampaignRole);
+
+export default router;

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import {
+  getUsers,
+  getUserById,
+  createUser,
+  updateUser,
+  deleteUser,
+  getUserCampaigns,
+  getUserCharacters,
+  getUserSystemRoles,
+  assignSystemRoleToUser
+} from '../controllers/userController.js';
+
+const router = Router();
+
+router.get('/', getUsers);
+router.get('/:id', getUserById);
+router.post('/', createUser);
+router.put('/:id', updateUser);
+router.delete('/:id', deleteUser);
+router.get('/:id/campaigns', getUserCampaigns);
+router.get('/:id/characters', getUserCharacters);
+router.get('/:id/system-roles', getUserSystemRoles);
+router.post('/:id/system-roles', assignSystemRoleToUser);
+
+export default router;

--- a/backend/src/routes/worldRoutes.js
+++ b/backend/src/routes/worldRoutes.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import {
+  getWorlds,
+  getWorldById,
+  createWorld,
+  updateWorld,
+  deleteWorld,
+  getWorldCampaigns
+} from '../controllers/worldController.js';
+
+const router = Router();
+
+router.get('/', getWorlds);
+router.get('/:id', getWorldById);
+router.post('/', createWorld);
+router.put('/:id', updateWorld);
+router.delete('/:id', deleteWorld);
+router.get('/:id/campaigns', getWorldCampaigns);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,12 +1,19 @@
 import express from 'express';
 import { sequelize } from './models/index.js';
 import { cfg } from './config/env.js';
+import apiRoutes from './routes/index.js';
 
 const app = express();
 app.use(express.json());
 
-// simple route
+app.use('/api', apiRoutes);
+
 app.get('/', (req, res) => res.send('DnD_app backend running'));
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ success: false, message: err.message });
+});
 
 (async () => {
   try {


### PR DESCRIPTION
## Summary
- add controllers covering users, campaigns, roles, worlds, characters, and join tables with CRUD endpoints and relational lookups
- register dedicated routers for each resource and mount them under the /api namespace
- enrich Sequelize models with missing attributes and associations so controllers can return linked data

## Testing
- not run (database access not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4093f3d24832e95881bc294efddb3