### PR TITLE
Add frontend user management form for system roles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,190 @@
+:root {
+  color: #0f172a;
+  background-color: #f8fafc;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #e0f2fe 0%, #f8fafc 50%, #f1f5f9 100%);
+}
+
 #root {
-  max-width: 1280px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+header p {
+  margin: 0.5rem auto 0;
+  max-width: 42rem;
+  color: #475569;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+.panels {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 860px) {
+  .panels {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-.card {
-  padding: 2em;
+.panel {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.read-the-docs {
-  color: #888;
+.panel h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.form-field span {
+  font-size: 0.95rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
+}
+
+input[readonly] {
+  background: #e2e8f0;
+  cursor: not-allowed;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.5rem;
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.35);
+}
+
+.assigned-roles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.assigned-roles h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.assigned-roles p {
+  margin: 0;
+  color: #475569;
+}
+
+.assigned-roles ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.assigned-roles li {
+  background: #e0f2fe;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  color: #0369a1;
+}
+
+.message {
+  position: sticky;
+  bottom: 1.5rem;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  max-width: fit-content;
+}
+
+.message.success {
+  background: rgba(74, 222, 128, 0.2);
+  color: #166534;
+}
+
+.message.error {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,258 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api'
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [userForm, setUserForm] = useState({ username: '', email: '', password: '' })
+  const [isCreatingUser, setIsCreatingUser] = useState(false)
+  const [createdUser, setCreatedUser] = useState(null)
+  const [userRoles, setUserRoles] = useState([])
+  const [roles, setRoles] = useState([])
+  const [selectedRoleId, setSelectedRoleId] = useState('')
+  const [statusMessage, setStatusMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isAssigningRole, setIsAssigningRole] = useState(false)
+  const [rolesLoading, setRolesLoading] = useState(true)
+  const [userRolesLoading, setUserRolesLoading] = useState(false)
+
+  useEffect(() => {
+    const loadRoles = async () => {
+      try {
+        setRolesLoading(true)
+        const res = await fetch(`${API_BASE_URL}/system-roles`)
+        if (!res.ok) {
+          throw new Error('Unable to load system roles')
+        }
+        const payload = await res.json()
+        setRoles(payload.data || [])
+      } catch (error) {
+        console.error(error)
+        setErrorMessage(error.message || 'Failed to load system roles')
+      } finally {
+        setRolesLoading(false)
+      }
+    }
+
+    loadRoles()
+  }, [])
+
+  const resetMessages = () => {
+    setStatusMessage('')
+    setErrorMessage('')
+  }
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target
+    setUserForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleCreateUser = async (event) => {
+    event.preventDefault()
+    resetMessages()
+
+    if (!userForm.username || !userForm.email || !userForm.password) {
+      setErrorMessage('Please provide a username, email, and password before creating a user.')
+      return
+    }
+
+    setIsCreatingUser(true)
+    try {
+      const response = await fetch(`${API_BASE_URL}/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: userForm.username,
+          email: userForm.email,
+          password_hash: userForm.password
+        })
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.message || 'Unable to create user')
+      }
+
+      setCreatedUser(payload.data)
+      setUserRoles([])
+      setSelectedRoleId('')
+      await loadUserRoles(payload.data.id)
+      setStatusMessage('User created successfully. You can now assign a system role.')
+    } catch (error) {
+      console.error(error)
+      setErrorMessage(error.message)
+    } finally {
+      setIsCreatingUser(false)
+    }
+  }
+
+  const loadUserRoles = async (userId) => {
+    try {
+      setUserRolesLoading(true)
+      const res = await fetch(`${API_BASE_URL}/users/${userId}/system-roles`)
+      if (!res.ok) {
+        throw new Error('Unable to load system roles for the user')
+      }
+      const payload = await res.json()
+      setUserRoles(payload.data || [])
+    } catch (error) {
+      console.error(error)
+      setErrorMessage(error.message)
+    } finally {
+      setUserRolesLoading(false)
+    }
+  }
+
+  const handleAssignRole = async (event) => {
+    event.preventDefault()
+    resetMessages()
+
+    if (!createdUser) {
+      setErrorMessage('Create a user before assigning roles.')
+      return
+    }
+
+    if (!selectedRoleId) {
+      setErrorMessage('Select a system role to assign.')
+      return
+    }
+
+    setIsAssigningRole(true)
+    try {
+      const response = await fetch(`${API_BASE_URL}/users/${createdUser.id}/system-roles`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roleId: Number(selectedRoleId) })
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.message || 'Unable to assign system role')
+      }
+
+      setStatusMessage(payload.message || 'Role assigned successfully.')
+      await loadUserRoles(createdUser.id)
+    } catch (error) {
+      console.error(error)
+      setErrorMessage(error.message)
+    } finally {
+      setIsAssigningRole(false)
+    }
+  }
+
+  const userSummary = useMemo(() => {
+    if (!createdUser) return null
+    return `${createdUser.username} (${createdUser.email})`
+  }, [createdUser])
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app-shell">
+      <header>
+        <h1>System User Management</h1>
+        <p>Create a new system user and assign system-wide roles in a single place.</p>
+      </header>
+
+      <main className="panels">
+        <section className="panel">
+          <h2>Create system user</h2>
+          <form className="form" onSubmit={handleCreateUser}>
+            <label className="form-field">
+              <span>Username</span>
+              <input
+                name="username"
+                type="text"
+                placeholder="cleric42"
+                value={userForm.username}
+                onChange={handleInputChange}
+                autoComplete="username"
+              />
+            </label>
+
+            <label className="form-field">
+              <span>Email</span>
+              <input
+                name="email"
+                type="email"
+                placeholder="cleric42@example.com"
+                value={userForm.email}
+                onChange={handleInputChange}
+                autoComplete="email"
+              />
+            </label>
+
+            <label className="form-field">
+              <span>Password</span>
+              <input
+                name="password"
+                type="password"
+                placeholder="Enter a temporary password"
+                value={userForm.password}
+                onChange={handleInputChange}
+                autoComplete="new-password"
+              />
+            </label>
+
+            <button type="submit" disabled={isCreatingUser}>
+              {isCreatingUser ? 'Creating user…' : 'Create user'}
+            </button>
+          </form>
+        </section>
+
+        <section className="panel">
+          <h2>Assign a system role</h2>
+          <form className="form" onSubmit={handleAssignRole}>
+            <label className="form-field">
+              <span>User</span>
+              <input type="text" value={userSummary || 'No user created yet'} readOnly />
+            </label>
+
+            <label className="form-field">
+              <span>System role</span>
+              <select
+                value={selectedRoleId}
+                onChange={(event) => setSelectedRoleId(event.target.value)}
+                disabled={!createdUser || rolesLoading || roles.length === 0}
+              >
+                <option value="">{rolesLoading ? 'Loading roles…' : 'Select a system role'}</option>
+                {roles.map((role) => (
+                  <option key={role.id} value={role.id}>
+                    {role.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button type="submit" disabled={!createdUser || !selectedRoleId || isAssigningRole}>
+              {isAssigningRole ? 'Assigning role…' : 'Assign role'}
+            </button>
+          </form>
+
+          <div className="assigned-roles">
+            <h3>Assigned system roles</h3>
+            {!createdUser && <p>Create a user to view their roles.</p>}
+            {createdUser && userRolesLoading && <p>Loading…</p>}
+            {createdUser && !userRolesLoading && userRoles.length === 0 && (
+              <p>No roles assigned yet.</p>
+            )}
+            {createdUser && userRoles.length > 0 && (
+              <ul>
+                {userRoles.map((role) => (
+                  <li key={role.id}>{role.name}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </main>
+
+      {(statusMessage || errorMessage) && (
+        <div className={`message ${errorMessage ? 'error' : 'success'}`} role="status">
+          {errorMessage || statusMessage}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0f172a;
+  background-color: #f8fafc;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -14,55 +11,25 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #1d4ed8;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  color: inherit;
+  background-color: transparent;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button,
+input,
+select {
+  font: inherit;
 }


### PR DESCRIPTION
## Summary
- add a management panel that creates users and assigns them a system role from the API
- refresh the frontend styles to support the new workflow layout and messaging
- align the global typography and reset styles to match the updated design

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e40cc4e500832eaf1b711e151d570a