### PR TITLE
Fix role assignment by sending string roleId

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -123,7 +123,7 @@ function App() {
       const response = await fetch(`${API_BASE_URL}/users/${createdUser.id}/system-roles`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ roleId: Number(selectedRoleId) })
+        body: JSON.stringify({ roleId: selectedRoleId })
       })
 
       const payload = await response.json()


### PR DESCRIPTION
## Summary
- stop coercing the selected role ID to a number so UUID values reach the API when assigning roles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e414ae78ec832eb07231bf8bc817f6