### PR TITLE
feat: build platform admin app shell

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,190 +1,514 @@
-:root {
-  color: #0f172a;
-  background-color: #f8fafc;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.5;
-}
-
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top, #e0f2fe 0%, #f8fafc 50%, #f1f5f9 100%);
-}
-
-#root {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
-}
-
 .app-shell {
   display: flex;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 100%);
+  color: #0f172a;
+}
+
+.shell-sidebar {
+  width: 272px;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: #f8fafc;
+  display: flex;
   flex-direction: column;
+  padding: 2rem 1.5rem;
   gap: 2rem;
+  box-shadow: 0 0 32px rgba(15, 23, 42, 0.25);
+  z-index: 2;
 }
 
-header {
-  text-align: center;
+.sidebar-header .brand-mark {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
-header h1 {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 2.75rem);
+.sidebar-header .brand-subtitle {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  color: rgba(241, 245, 249, 0.8);
 }
 
-header p {
-  margin: 0.5rem auto 0;
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar-empty {
+  font-size: 0.875rem;
+  color: rgba(241, 245, 249, 0.75);
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: transparent;
+  color: inherit;
+  border: none;
+  font-size: 1rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar-link:hover,
+.sidebar-link:focus-visible {
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.sidebar-link.active {
+  background: rgba(96, 165, 250, 0.2);
+  color: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+}
+
+.shell-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.app-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 2rem 3rem 1.5rem;
+  background: rgba(248, 250, 252, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.breadcrumbs {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #475569;
+  align-items: center;
+}
+
+.breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.breadcrumb-item span[aria-hidden='true'] {
+  margin: 0 0.25rem;
+  color: rgba(71, 85, 105, 0.6);
+}
+
+.module-title {
+  margin: 0.5rem 0 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.module-description {
+  margin-top: 0.5rem;
   max-width: 42rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.current-user {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  color: #0f172a;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-role {
+  font-size: 0.875rem;
   color: #475569;
 }
 
-.panels {
-  display: grid;
-  gap: 1.5rem;
+.module-content {
+  flex: 1;
+  padding: 2rem 3rem 3rem;
+  min-width: 0;
 }
 
-@media (min-width: 860px) {
-  .panels {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.panel {
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(12px);
-  border-radius: 1.5rem;
-  padding: 2rem;
-  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25);
+.platform-admin {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
-.panel h2 {
-  margin: 0;
-  font-size: 1.5rem;
+.section-tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.section-tab {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #475569;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.section-tab:hover,
+.section-tab:focus-visible {
+  background: rgba(255, 255, 255, 0.8);
   color: #0f172a;
 }
 
-.form {
+.section-tab.active {
+  background: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.25);
+}
+
+.standard-list {
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.list-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.list-header p {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.list-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.column-visibility {
+  position: relative;
+}
+
+.column-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: #ffffff;
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.15);
+  padding: 0.75rem;
+  min-width: 200px;
+  display: grid;
+  gap: 0.5rem;
+  z-index: 10;
+}
+
+.table-container {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.table-container table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+}
+
+.table-container th,
+.table-container td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.75);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.table-container thead {
+  background: rgba(226, 232, 240, 0.4);
+  font-size: 0.875rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.table-container tbody tr:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.actions-header {
+  width: 140px;
+  text-align: right;
+}
+
+.row-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.25rem;
+}
+
+.button-group,
+.drawer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+button.primary {
+  background: #2563eb;
+  color: #f8fafc;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+button.ghost {
+  background: rgba(148, 163, 184, 0.2);
+  color: #0f172a;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.6rem 1.25rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+button.ghost:hover,
+button.ghost:focus-visible {
+  background: rgba(15, 23, 42, 0.1);
+}
+
+button.ghost.destructive {
+  color: #b91c1c;
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 1rem;
+  padding: 2rem;
+  text-align: center;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  color: #475569;
+}
+
+.drawer-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drawer-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.record-drawer {
+  position: relative;
+  width: min(420px, 100%);
+  background: #ffffff;
+  height: 100vh;
+  box-shadow: -18px 0 48px rgba(15, 23, 42, 0.18);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.drawer-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.form-field {
+.drawer-form label {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-weight: 600;
-  color: #1e293b;
-}
-
-.form-field span {
-  font-size: 0.95rem;
-}
-
-input,
-select,
-button {
-  font: inherit;
-}
-
-input,
-select {
-  padding: 0.75rem 1rem;
-  border: 1px solid #cbd5f5;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-input:focus,
-select:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
-}
-
-input[readonly] {
-  background: #e2e8f0;
-  cursor: not-allowed;
-}
-
-button {
-  cursor: pointer;
-  border: none;
-  border-radius: 999px;
-  padding: 0.85rem 1.5rem;
-  background: linear-gradient(135deg, #3b82f6, #6366f1);
-  color: white;
-  font-weight: 600;
-  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.35);
-}
-
-.assigned-roles {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.assigned-roles h3 {
-  margin: 0;
-  font-size: 1.1rem;
+  gap: 0.35rem;
+  font-weight: 500;
   color: #0f172a;
 }
 
-.assigned-roles p {
-  margin: 0;
-  color: #475569;
+.drawer-form input,
+.drawer-form select,
+.drawer-form textarea {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  color: inherit;
+  background: #ffffff;
 }
 
-.assigned-roles ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
+.drawer-form textarea {
+  resize: vertical;
+}
+
+.roles-fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: grid;
   gap: 0.5rem;
 }
 
-.assigned-roles li {
-  background: #e0f2fe;
-  border-radius: 999px;
-  padding: 0.35rem 0.85rem;
+.roles-fieldset legend {
+  padding: 0 0.5rem;
   font-weight: 600;
-  color: #0369a1;
+  color: #0f172a;
 }
 
-.message {
-  position: sticky;
-  bottom: 1.5rem;
-  margin: 0 auto;
-  padding: 1rem 1.5rem;
-  border-radius: 999px;
-  font-weight: 600;
-  max-width: fit-content;
+.checkbox-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: inherit;
 }
 
-.message.success {
-  background: rgba(74, 222, 128, 0.2);
-  color: #166534;
+.checkbox-option input {
+  width: 1rem;
+  height: 1rem;
 }
 
-.message.error {
-  background: rgba(248, 113, 113, 0.2);
-  color: #b91c1c;
+.helper-text {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.drawer-subsection {
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.drawer-subsection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.assignment-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.assignment-row label {
+  font-weight: 500;
+}
+
+@media (max-width: 1080px) {
+  .app-header {
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+  }
+
+  .current-user {
+    align-items: flex-start;
+  }
+
+  .list-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .list-actions {
+    align-self: stretch;
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+  .assignment-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 860px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .shell-sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .module-content {
+    padding: 1.5rem;
+  }
+
+  .app-header {
+    padding: 1.5rem;
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,257 +1,1037 @@
 import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api'
+const seededRoles = [
+  {
+    id: 'role-system-admin',
+    name: 'System Administrator',
+    description: 'Full platform access and configuration rights.',
+    createdAt: '2024-01-12T10:15:00Z',
+    updatedAt: '2024-04-01T08:25:00Z'
+  },
+  {
+    id: 'role-dungeon-master',
+    name: 'Dungeon Master',
+    description: 'Owns the storytelling experience for a campaign.',
+    createdAt: '2024-02-06T14:10:00Z',
+    updatedAt: '2024-03-18T09:32:00Z'
+  },
+  {
+    id: 'role-player',
+    name: 'Player',
+    description: 'Participates in assigned campaigns with scoped permissions.',
+    createdAt: '2024-02-06T14:10:00Z',
+    updatedAt: '2024-03-18T09:32:00Z'
+  }
+]
+
+const seededUsers = [
+  {
+    id: 'user-aelar',
+    displayName: 'Aelar Morningstar',
+    email: 'aelar@example.com',
+    username: 'aelar',
+    password: 'Temp!123',
+    status: 'Active',
+    roles: ['role-system-admin'],
+    updatedAt: '2024-04-18T12:02:00Z'
+  },
+  {
+    id: 'user-lyra',
+    displayName: 'Lyra Willowstep',
+    email: 'lyra@example.com',
+    username: 'lyra',
+    password: 'Welcome1',
+    status: 'Invited',
+    roles: ['role-player'],
+    updatedAt: '2024-04-11T09:44:00Z'
+  }
+]
+
+const seededCampaigns = [
+  {
+    id: 'campaign-tiamat',
+    name: 'Rise of Tiamat',
+    status: 'Planning',
+    summary: 'High level threat from the Dragon Queen.',
+    assignments: [
+      { id: 'assign-1', userId: 'user-aelar', roleId: 'role-dungeon-master' },
+      { id: 'assign-2', userId: 'user-lyra', roleId: 'role-player' }
+    ],
+    updatedAt: '2024-04-14T21:00:00Z'
+  }
+]
+
+const modules = [
+  {
+    id: 'platform-admin',
+    label: 'Platform Admin',
+    description: 'Manage users, roles, and campaigns across the multiverse.'
+  }
+]
+
+const sections = [
+  { id: 'users', label: 'Users' },
+  { id: 'roles', label: 'Roles' },
+  { id: 'campaigns', label: 'Campaigns' }
+]
+
+const capabilityMatrix = {
+  'platform-admin': {
+    'system-admin': ['view', 'manage-users', 'manage-roles', 'manage-campaigns']
+  }
+}
+
+const newId = (prefix) => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`
+}
 
 function App() {
-  const [userForm, setUserForm] = useState({ username: '', email: '', password: '' })
-  const [isCreatingUser, setIsCreatingUser] = useState(false)
-  const [createdUser, setCreatedUser] = useState(null)
-  const [userRoles, setUserRoles] = useState([])
-  const [roles, setRoles] = useState([])
-  const [selectedRoleId, setSelectedRoleId] = useState('')
-  const [statusMessage, setStatusMessage] = useState('')
-  const [errorMessage, setErrorMessage] = useState('')
-  const [isAssigningRole, setIsAssigningRole] = useState(false)
-  const [rolesLoading, setRolesLoading] = useState(true)
-  const [userRolesLoading, setUserRolesLoading] = useState(false)
+  const [currentUser] = useState({
+    id: 'user-aelar',
+    name: 'Aelar Morningstar',
+    roles: ['system-admin']
+  })
+
+  const [activeModuleId, setActiveModuleId] = useState('platform-admin')
+  const [activeSectionId, setActiveSectionId] = useState('users')
+
+  const [roles, setRoles] = useState(seededRoles)
+  const [users, setUsers] = useState(seededUsers)
+  const [campaigns, setCampaigns] = useState(seededCampaigns)
+
+  const permissions = useMemo(() => {
+    const modulePermissions = capabilityMatrix['platform-admin'] || {}
+    const derivedPermissions = new Set()
+
+    currentUser.roles.forEach((roleKey) => {
+      const capabilities = modulePermissions[roleKey]
+      if (capabilities) {
+        capabilities.forEach((cap) => derivedPermissions.add(cap))
+      }
+    })
+
+    return {
+      canViewPlatformAdmin: derivedPermissions.has('view'),
+      canManageUsers: derivedPermissions.has('manage-users'),
+      canManageRoles: derivedPermissions.has('manage-roles'),
+      canManageCampaigns: derivedPermissions.has('manage-campaigns')
+    }
+  }, [currentUser.roles])
 
   useEffect(() => {
-    const loadRoles = async () => {
-      try {
-        setRolesLoading(true)
-        const res = await fetch(`${API_BASE_URL}/system-roles`)
-        if (!res.ok) {
-          throw new Error('Unable to load system roles')
+    if (!permissions.canViewPlatformAdmin) {
+      setActiveModuleId(null)
+    }
+  }, [permissions.canViewPlatformAdmin])
+
+  const breadcrumbs = useMemo(() => {
+    const trail = ['Home']
+
+    if (activeModuleId) {
+      const module = modules.find((item) => item.id === activeModuleId)
+      if (module) {
+        trail.push(module.label)
+      }
+    }
+
+    if (activeSectionId) {
+      const section = sections.find((item) => item.id === activeSectionId)
+      if (section) {
+        trail.push(section.label)
+      }
+    }
+
+    return trail
+  }, [activeModuleId, activeSectionId])
+
+  const moduleDescription = useMemo(() => {
+    if (!activeModuleId) return ''
+    const module = modules.find((item) => item.id === activeModuleId)
+    return module?.description || ''
+  }, [activeModuleId])
+
+  const sidebarModules = useMemo(() => {
+    if (!permissions.canViewPlatformAdmin) {
+      return []
+    }
+
+    return modules
+  }, [permissions.canViewPlatformAdmin])
+
+  const updateUsersWithRoleRemoval = (roleId) => {
+    setUsers((prev) =>
+      prev.map((user) => {
+        if (!user.roles.includes(roleId)) return user
+        const nextRoles = user.roles.filter((id) => id !== roleId)
+        return { ...user, roles: nextRoles, updatedAt: new Date().toISOString() }
+      })
+    )
+  }
+
+  const updateCampaignsWithRoleRemoval = (roleId) => {
+    setCampaigns((prev) =>
+      prev.map((campaign) => {
+        const nextAssignments = campaign.assignments.filter((assignment) => assignment.roleId !== roleId)
+        if (nextAssignments.length === campaign.assignments.length) {
+          return campaign
         }
-        const payload = await res.json()
-        setRoles(payload.data || [])
-      } catch (error) {
-        console.error(error)
-        setErrorMessage(error.message || 'Failed to load system roles')
-      } finally {
-        setRolesLoading(false)
-      }
-    }
-
-    loadRoles()
-  }, [])
-
-  const resetMessages = () => {
-    setStatusMessage('')
-    setErrorMessage('')
+        return { ...campaign, assignments: nextAssignments, updatedAt: new Date().toISOString() }
+      })
+    )
   }
 
-  const handleInputChange = (event) => {
-    const { name, value } = event.target
-    setUserForm((prev) => ({ ...prev, [name]: value }))
+  const updateCampaignsWithUserRemoval = (userId) => {
+    setCampaigns((prev) =>
+      prev.map((campaign) => {
+        const nextAssignments = campaign.assignments.filter((assignment) => assignment.userId !== userId)
+        if (nextAssignments.length === campaign.assignments.length) {
+          return campaign
+        }
+        return { ...campaign, assignments: nextAssignments, updatedAt: new Date().toISOString() }
+      })
+    )
   }
 
-  const handleCreateUser = async (event) => {
-    event.preventDefault()
-    resetMessages()
-
-    if (!userForm.username || !userForm.email || !userForm.password) {
-      setErrorMessage('Please provide a username, email, and password before creating a user.')
+  const handleSaveRole = (payload, mode) => {
+    if (mode === 'edit') {
+      setRoles((prev) =>
+        prev.map((role) => (role.id === payload.id ? { ...role, ...payload, updatedAt: new Date().toISOString() } : role))
+      )
       return
     }
 
-    setIsCreatingUser(true)
-    try {
-      const response = await fetch(`${API_BASE_URL}/users`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          username: userForm.username,
-          email: userForm.email,
-          password_hash: userForm.password
+    setRoles((prev) => [
+      ...prev,
+      {
+        ...payload,
+        id: newId('role'),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }
+    ])
+  }
+
+  const handleDeleteRole = (roleId) => {
+    setRoles((prev) => prev.filter((role) => role.id !== roleId))
+    updateUsersWithRoleRemoval(roleId)
+    updateCampaignsWithRoleRemoval(roleId)
+  }
+
+  const handleSaveUser = (payload, mode) => {
+    if (mode === 'edit') {
+      setUsers((prev) =>
+        prev.map((user) => {
+          if (user.id !== payload.id) return user
+          const nextPassword = payload.password ? payload.password : user.password
+          return {
+            ...user,
+            ...payload,
+            password: nextPassword,
+            updatedAt: new Date().toISOString()
+          }
         })
-      })
-
-      const payload = await response.json()
-
-      if (!response.ok) {
-        throw new Error(payload.message || 'Unable to create user')
-      }
-
-      setCreatedUser(payload.data)
-      setUserRoles([])
-      setSelectedRoleId('')
-      await loadUserRoles(payload.data.id)
-      setStatusMessage('User created successfully. You can now assign a system role.')
-    } catch (error) {
-      console.error(error)
-      setErrorMessage(error.message)
-    } finally {
-      setIsCreatingUser(false)
-    }
-  }
-
-  const loadUserRoles = async (userId) => {
-    try {
-      setUserRolesLoading(true)
-      const res = await fetch(`${API_BASE_URL}/users/${userId}/system-roles`)
-      if (!res.ok) {
-        throw new Error('Unable to load system roles for the user')
-      }
-      const payload = await res.json()
-      setUserRoles(payload.data || [])
-    } catch (error) {
-      console.error(error)
-      setErrorMessage(error.message)
-    } finally {
-      setUserRolesLoading(false)
-    }
-  }
-
-  const handleAssignRole = async (event) => {
-    event.preventDefault()
-    resetMessages()
-
-    if (!createdUser) {
-      setErrorMessage('Create a user before assigning roles.')
+      )
       return
     }
 
-    if (!selectedRoleId) {
-      setErrorMessage('Select a system role to assign.')
+    setUsers((prev) => [
+      ...prev,
+      {
+        ...payload,
+        id: newId('user'),
+        status: payload.status || 'Invited',
+        updatedAt: new Date().toISOString()
+      }
+    ])
+  }
+
+  const handleDeleteUser = (userId) => {
+    setUsers((prev) => prev.filter((user) => user.id !== userId))
+    updateCampaignsWithUserRemoval(userId)
+  }
+
+  const handleSaveCampaign = (payload, mode) => {
+    if (mode === 'edit') {
+      setCampaigns((prev) =>
+        prev.map((campaign) =>
+          campaign.id === payload.id
+            ? {
+                ...campaign,
+                ...payload,
+                updatedAt: new Date().toISOString()
+              }
+            : campaign
+        )
+      )
       return
     }
 
-    setIsAssigningRole(true)
-    try {
-      const response = await fetch(`${API_BASE_URL}/users/${createdUser.id}/system-roles`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ roleId: selectedRoleId })
-      })
-
-      const payload = await response.json()
-
-      if (!response.ok) {
-        throw new Error(payload.message || 'Unable to assign system role')
+    setCampaigns((prev) => [
+      ...prev,
+      {
+        ...payload,
+        id: newId('campaign'),
+        updatedAt: new Date().toISOString()
       }
-
-      setStatusMessage(payload.message || 'Role assigned successfully.')
-      await loadUserRoles(createdUser.id)
-    } catch (error) {
-      console.error(error)
-      setErrorMessage(error.message)
-    } finally {
-      setIsAssigningRole(false)
-    }
+    ])
   }
 
-  const userSummary = useMemo(() => {
-    if (!createdUser) return null
-    return `${createdUser.username} (${createdUser.email})`
-  }, [createdUser])
+  const handleDeleteCampaign = (campaignId) => {
+    setCampaigns((prev) => prev.filter((campaign) => campaign.id !== campaignId))
+  }
 
   return (
     <div className="app-shell">
-      <header>
-        <h1>System User Management</h1>
-        <p>Create a new system user and assign system-wide roles in a single place.</p>
-      </header>
-
-      <main className="panels">
-        <section className="panel">
-          <h2>Create system user</h2>
-          <form className="form" onSubmit={handleCreateUser}>
-            <label className="form-field">
-              <span>Username</span>
-              <input
-                name="username"
-                type="text"
-                placeholder="cleric42"
-                value={userForm.username}
-                onChange={handleInputChange}
-                autoComplete="username"
-              />
-            </label>
-
-            <label className="form-field">
-              <span>Email</span>
-              <input
-                name="email"
-                type="email"
-                placeholder="cleric42@example.com"
-                value={userForm.email}
-                onChange={handleInputChange}
-                autoComplete="email"
-              />
-            </label>
-
-            <label className="form-field">
-              <span>Password</span>
-              <input
-                name="password"
-                type="password"
-                placeholder="Enter a temporary password"
-                value={userForm.password}
-                onChange={handleInputChange}
-                autoComplete="new-password"
-              />
-            </label>
-
-            <button type="submit" disabled={isCreatingUser}>
-              {isCreatingUser ? 'Creating user…' : 'Create user'}
-            </button>
-          </form>
-        </section>
-
-        <section className="panel">
-          <h2>Assign a system role</h2>
-          <form className="form" onSubmit={handleAssignRole}>
-            <label className="form-field">
-              <span>User</span>
-              <input type="text" value={userSummary || 'No user created yet'} readOnly />
-            </label>
-
-            <label className="form-field">
-              <span>System role</span>
-              <select
-                value={selectedRoleId}
-                onChange={(event) => setSelectedRoleId(event.target.value)}
-                disabled={!createdUser || rolesLoading || roles.length === 0}
+      <aside className="shell-sidebar">
+        <div className="sidebar-header">
+          <div className="brand-mark">DnD Platform</div>
+          <p className="brand-subtitle">Orchestrate adventures with confidence.</p>
+        </div>
+        <nav className="sidebar-nav">
+          {sidebarModules.length === 0 && <p className="sidebar-empty">No modules available for your role.</p>}
+          {sidebarModules.map((module) => {
+            const isActive = module.id === activeModuleId
+            return (
+              <button
+                key={module.id}
+                className={`sidebar-link${isActive ? ' active' : ''}`}
+                type="button"
+                onClick={() => setActiveModuleId(module.id)}
               >
-                <option value="">{rolesLoading ? 'Loading roles…' : 'Select a system role'}</option>
-                {roles.map((role) => (
-                  <option key={role.id} value={role.id}>
-                    {role.name}
-                  </option>
-                ))}
-              </select>
-            </label>
+                <span>{module.label}</span>
+              </button>
+            )
+          })}
+        </nav>
+      </aside>
 
-            <button type="submit" disabled={!createdUser || !selectedRoleId || isAssigningRole}>
-              {isAssigningRole ? 'Assigning role…' : 'Assign role'}
+      <div className="shell-main">
+        <header className="app-header">
+          <div>
+            <nav className="breadcrumbs" aria-label="Breadcrumb">
+              {breadcrumbs.map((item, index) => (
+                <span key={item} className="breadcrumb-item">
+                  {item}
+                  {index < breadcrumbs.length - 1 && <span aria-hidden="true">›</span>}
+                </span>
+              ))}
+            </nav>
+            <h1 className="module-title">{breadcrumbs[breadcrumbs.length - 1]}</h1>
+            {moduleDescription && <p className="module-description">{moduleDescription}</p>}
+          </div>
+
+          <div className="current-user">
+            <span className="user-name">{currentUser.name}</span>
+            <span className="user-role">{currentUser.roles.map((role) => role.replace('-', ' ')).join(', ')}</span>
+          </div>
+        </header>
+
+        <main className="module-content">
+          {!permissions.canViewPlatformAdmin && (
+            <div className="empty-state">
+              <h2>Access restricted</h2>
+              <p>You currently do not have permission to administer the platform.</p>
+            </div>
+          )}
+
+          {permissions.canViewPlatformAdmin && activeModuleId === 'platform-admin' && (
+            <PlatformAdmin
+              activeSectionId={activeSectionId}
+              onSectionChange={setActiveSectionId}
+              users={users}
+              roles={roles}
+              campaigns={campaigns}
+              permissions={permissions}
+              onSaveUser={handleSaveUser}
+              onDeleteUser={handleDeleteUser}
+              onSaveRole={handleSaveRole}
+              onDeleteRole={handleDeleteRole}
+              onSaveCampaign={handleSaveCampaign}
+              onDeleteCampaign={handleDeleteCampaign}
+            />
+          )}
+        </main>
+      </div>
+    </div>
+  )
+}
+
+function PlatformAdmin({
+  activeSectionId,
+  onSectionChange,
+  users,
+  roles,
+  campaigns,
+  permissions,
+  onSaveUser,
+  onDeleteUser,
+  onSaveRole,
+  onDeleteRole,
+  onSaveCampaign,
+  onDeleteCampaign
+}) {
+  const [userDrawer, setUserDrawer] = useState({ open: false, mode: 'create', record: null })
+  const [roleDrawer, setRoleDrawer] = useState({ open: false, mode: 'create', record: null })
+  const [campaignDrawer, setCampaignDrawer] = useState({ open: false, mode: 'create', record: null })
+
+  const [userForm, setUserForm] = useState({ displayName: '', email: '', username: '', password: '', roles: [], status: 'Invited' })
+  const [roleForm, setRoleForm] = useState({ name: '', description: '' })
+  const [campaignForm, setCampaignForm] = useState({ name: '', status: 'Draft', summary: '', assignments: [] })
+
+  useEffect(() => {
+    if (!userDrawer.open) {
+      setUserForm({ displayName: '', email: '', username: '', password: '', roles: [], status: 'Invited' })
+    }
+  }, [userDrawer.open])
+
+  useEffect(() => {
+    if (!roleDrawer.open) {
+      setRoleForm({ name: '', description: '' })
+    }
+  }, [roleDrawer.open])
+
+  useEffect(() => {
+    if (!campaignDrawer.open) {
+      setCampaignForm({ name: '', status: 'Draft', summary: '', assignments: [] })
+    }
+  }, [campaignDrawer.open])
+
+  const openCreateUser = () => {
+    setUserDrawer({ open: true, mode: 'create', record: null })
+  }
+
+  const openEditUser = (record) => {
+    setUserForm({
+      displayName: record.displayName,
+      email: record.email,
+      username: record.username,
+      password: '',
+      roles: record.roles,
+      status: record.status,
+      id: record.id
+    })
+    setUserDrawer({ open: true, mode: 'edit', record })
+  }
+
+  const openCreateRole = () => {
+    setRoleDrawer({ open: true, mode: 'create', record: null })
+  }
+
+  const openEditRole = (record) => {
+    setRoleForm({ name: record.name, description: record.description, id: record.id })
+    setRoleDrawer({ open: true, mode: 'edit', record })
+  }
+
+  const openCreateCampaign = () => {
+    setCampaignDrawer({ open: true, mode: 'create', record: null })
+  }
+
+  const openEditCampaign = (record) => {
+    setCampaignForm({
+      id: record.id,
+      name: record.name,
+      status: record.status,
+      summary: record.summary,
+      assignments: record.assignments.map((assignment) => ({ ...assignment }))
+    })
+    setCampaignDrawer({ open: true, mode: 'edit', record })
+  }
+
+  const closeUserDrawer = () => setUserDrawer((prev) => ({ ...prev, open: false }))
+  const closeRoleDrawer = () => setRoleDrawer((prev) => ({ ...prev, open: false }))
+  const closeCampaignDrawer = () => setCampaignDrawer((prev) => ({ ...prev, open: false }))
+
+  const userColumns = useMemo(
+    () => [
+      { id: 'displayName', label: 'Name', accessor: (record) => record.displayName },
+      { id: 'email', label: 'Email', accessor: (record) => record.email },
+      { id: 'username', label: 'Username', accessor: (record) => record.username },
+      {
+        id: 'roles',
+        label: 'Roles',
+        accessor: (record) =>
+          record.roles
+            .map((roleId) => roles.find((role) => role.id === roleId)?.name || roleId)
+            .join(', ') || '—'
+      },
+      { id: 'status', label: 'Status', accessor: (record) => record.status },
+      {
+        id: 'updatedAt',
+        label: 'Last updated',
+        accessor: (record) => new Date(record.updatedAt).toLocaleString()
+      }
+    ],
+    [roles]
+  )
+
+  const roleColumns = useMemo(
+    () => [
+      { id: 'name', label: 'Role name', accessor: (record) => record.name },
+      { id: 'description', label: 'Description', accessor: (record) => record.description || '—' },
+      {
+        id: 'createdAt',
+        label: 'Created',
+        accessor: (record) => new Date(record.createdAt).toLocaleDateString()
+      },
+      {
+        id: 'updatedAt',
+        label: 'Last updated',
+        accessor: (record) => new Date(record.updatedAt).toLocaleDateString()
+      }
+    ],
+    []
+  )
+
+  const campaignColumns = useMemo(
+    () => [
+      { id: 'name', label: 'Campaign', accessor: (record) => record.name },
+      { id: 'status', label: 'Status', accessor: (record) => record.status },
+      {
+        id: 'summary',
+        label: 'Summary',
+        accessor: (record) => record.summary || '—',
+        defaultVisible: false
+      },
+      {
+        id: 'assignments',
+        label: 'Assignments',
+        accessor: (record) => `${record.assignments.length} linked`
+      },
+      {
+        id: 'updatedAt',
+        label: 'Last updated',
+        accessor: (record) => new Date(record.updatedAt).toLocaleString()
+      }
+    ],
+    []
+  )
+
+  const handleSubmitUser = (event) => {
+    event.preventDefault()
+    onSaveUser(userForm, userDrawer.mode)
+    closeUserDrawer()
+  }
+
+  const handleSubmitRole = (event) => {
+    event.preventDefault()
+    onSaveRole(roleForm, roleDrawer.mode)
+    closeRoleDrawer()
+  }
+
+  const handleSubmitCampaign = (event) => {
+    event.preventDefault()
+    onSaveCampaign({
+      ...campaignForm,
+      assignments: campaignForm.assignments.filter((assignment) => assignment.userId && assignment.roleId)
+    }, campaignDrawer.mode)
+    closeCampaignDrawer()
+  }
+
+  const handleAddCampaignAssignment = () => {
+    setCampaignForm((prev) => ({
+      ...prev,
+      assignments: [
+        ...prev.assignments,
+        { id: newId('assignment'), userId: users[0]?.id ?? '', roleId: roles[0]?.id ?? '' }
+      ]
+    }))
+  }
+
+  const handleUpdateCampaignAssignment = (assignmentId, key, value) => {
+    setCampaignForm((prev) => ({
+      ...prev,
+      assignments: prev.assignments.map((assignment) =>
+        assignment.id === assignmentId ? { ...assignment, [key]: value } : assignment
+      )
+    }))
+  }
+
+  const handleRemoveCampaignAssignment = (assignmentId) => {
+    setCampaignForm((prev) => ({
+      ...prev,
+      assignments: prev.assignments.filter((assignment) => assignment.id !== assignmentId)
+    }))
+  }
+
+  return (
+    <div className="platform-admin">
+      <div className="section-tabs" role="tablist">
+        {sections.map((section) => (
+          <button
+            key={section.id}
+            type="button"
+            role="tab"
+            aria-selected={activeSectionId === section.id}
+            className={`section-tab${activeSectionId === section.id ? ' active' : ''}`}
+            onClick={() => onSectionChange(section.id)}
+          >
+            {section.label}
+          </button>
+        ))}
+      </div>
+
+      {activeSectionId === 'users' && (
+        <StandardListView
+          entityName="User"
+          columns={userColumns}
+          records={users}
+          onCreate={permissions.canManageUsers ? openCreateUser : undefined}
+          onEdit={permissions.canManageUsers ? openEditUser : undefined}
+          onDelete={permissions.canManageUsers ? onDeleteUser : undefined}
+          emptyMessage="Invite your first adventurer to the platform."
+        />
+      )}
+
+      {activeSectionId === 'roles' && (
+        <StandardListView
+          entityName="Role"
+          columns={roleColumns}
+          records={roles}
+          onCreate={permissions.canManageRoles ? openCreateRole : undefined}
+          onEdit={permissions.canManageRoles ? openEditRole : undefined}
+          onDelete={permissions.canManageRoles ? onDeleteRole : undefined}
+          emptyMessage="Create a role to orchestrate platform access."
+        />
+      )}
+
+      {activeSectionId === 'campaigns' && (
+        <StandardListView
+          entityName="Campaign"
+          columns={campaignColumns}
+          records={campaigns}
+          onCreate={permissions.canManageCampaigns ? openCreateCampaign : undefined}
+          onEdit={permissions.canManageCampaigns ? openEditCampaign : undefined}
+          onDelete={permissions.canManageCampaigns ? onDeleteCampaign : undefined}
+          emptyMessage="Launch your first campaign and assemble a party."
+        />
+      )}
+
+      <RecordDrawer
+        open={userDrawer.open}
+        title={userDrawer.mode === 'edit' ? 'Edit user' : 'Invite user'}
+        onClose={closeUserDrawer}
+      >
+        <form className="drawer-form" onSubmit={handleSubmitUser}>
+          <label>
+            <span>Display name</span>
+            <input
+              required
+              type="text"
+              value={userForm.displayName}
+              onChange={(event) => setUserForm((prev) => ({ ...prev, displayName: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Email</span>
+            <input
+              required
+              type="email"
+              value={userForm.email}
+              onChange={(event) => setUserForm((prev) => ({ ...prev, email: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Username</span>
+            <input
+              required
+              type="text"
+              value={userForm.username}
+              onChange={(event) => setUserForm((prev) => ({ ...prev, username: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Password</span>
+            <input
+              type="password"
+              placeholder={userDrawer.mode === 'edit' ? 'Leave blank to keep current password' : ''}
+              required={userDrawer.mode === 'create'}
+              value={userForm.password}
+              onChange={(event) => setUserForm((prev) => ({ ...prev, password: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Status</span>
+            <select
+              value={userForm.status}
+              onChange={(event) => setUserForm((prev) => ({ ...prev, status: event.target.value }))}
+            >
+              <option value="Invited">Invited</option>
+              <option value="Active">Active</option>
+              <option value="Suspended">Suspended</option>
+            </select>
+          </label>
+
+          <fieldset className="roles-fieldset">
+            <legend>Roles</legend>
+            {roles.length === 0 && <p className="helper-text">No roles available yet.</p>}
+            {roles.map((role) => {
+              const checked = userForm.roles.includes(role.id)
+              return (
+                <label key={role.id} className="checkbox-option">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => {
+                      const { checked: isChecked } = event.target
+                      setUserForm((prev) => ({
+                        ...prev,
+                        roles: isChecked
+                          ? [...prev.roles, role.id]
+                          : prev.roles.filter((roleId) => roleId !== role.id)
+                      }))
+                    }}
+                  />
+                  <span>{role.name}</span>
+                </label>
+              )
+            })}
+          </fieldset>
+
+          <div className="drawer-actions">
+            <button type="button" className="ghost" onClick={closeUserDrawer}>
+              Cancel
             </button>
-          </form>
+            <button type="submit" className="primary">
+              {userDrawer.mode === 'edit' ? 'Save changes' : 'Invite user'}
+            </button>
+          </div>
+        </form>
+      </RecordDrawer>
 
-          <div className="assigned-roles">
-            <h3>Assigned system roles</h3>
-            {!createdUser && <p>Create a user to view their roles.</p>}
-            {createdUser && userRolesLoading && <p>Loading…</p>}
-            {createdUser && !userRolesLoading && userRoles.length === 0 && (
-              <p>No roles assigned yet.</p>
-            )}
-            {createdUser && userRoles.length > 0 && (
-              <ul>
-                {userRoles.map((role) => (
-                  <li key={role.id}>{role.name}</li>
+      <RecordDrawer
+        open={roleDrawer.open}
+        title={roleDrawer.mode === 'edit' ? 'Edit role' : 'Create role'}
+        onClose={closeRoleDrawer}
+      >
+        <form className="drawer-form" onSubmit={handleSubmitRole}>
+          <label>
+            <span>Role name</span>
+            <input
+              required
+              type="text"
+              value={roleForm.name}
+              onChange={(event) => setRoleForm((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Description</span>
+            <textarea
+              rows={4}
+              value={roleForm.description}
+              onChange={(event) => setRoleForm((prev) => ({ ...prev, description: event.target.value }))}
+            />
+          </label>
+
+          <div className="drawer-actions">
+            <button type="button" className="ghost" onClick={closeRoleDrawer}>
+              Cancel
+            </button>
+            <button type="submit" className="primary">
+              {roleDrawer.mode === 'edit' ? 'Save changes' : 'Create role'}
+            </button>
+          </div>
+        </form>
+      </RecordDrawer>
+
+      <RecordDrawer
+        open={campaignDrawer.open}
+        title={campaignDrawer.mode === 'edit' ? 'Edit campaign' : 'Create campaign'}
+        onClose={closeCampaignDrawer}
+      >
+        <form className="drawer-form" onSubmit={handleSubmitCampaign}>
+          <label>
+            <span>Campaign name</span>
+            <input
+              required
+              type="text"
+              value={campaignForm.name}
+              onChange={(event) => setCampaignForm((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </label>
+
+          <label>
+            <span>Status</span>
+            <select
+              value={campaignForm.status}
+              onChange={(event) => setCampaignForm((prev) => ({ ...prev, status: event.target.value }))}
+            >
+              <option value="Draft">Draft</option>
+              <option value="Planning">Planning</option>
+              <option value="Active">Active</option>
+              <option value="Completed">Completed</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Summary</span>
+            <textarea
+              rows={4}
+              value={campaignForm.summary}
+              onChange={(event) => setCampaignForm((prev) => ({ ...prev, summary: event.target.value }))}
+            />
+          </label>
+
+          <div className="drawer-subsection">
+            <div className="drawer-subsection-header">
+              <h4>Assignments</h4>
+              <button
+                type="button"
+                className="ghost"
+                onClick={handleAddCampaignAssignment}
+                disabled={users.length === 0 || roles.length === 0}
+              >
+                Add assignment
+              </button>
+            </div>
+
+            {campaignForm.assignments.length === 0 && <p className="helper-text">Link players and storytellers to the campaign.</p>}
+
+            {campaignForm.assignments.map((assignment) => (
+              <div key={assignment.id} className="assignment-row">
+                <label>
+                  <span>User</span>
+                  <select
+                    value={assignment.userId}
+                    onChange={(event) =>
+                      handleUpdateCampaignAssignment(assignment.id, 'userId', event.target.value)
+                    }
+                  >
+                    <option value="">Select user</option>
+                    {users.map((user) => (
+                      <option key={user.id} value={user.id}>
+                        {user.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label>
+                  <span>Role</span>
+                  <select
+                    value={assignment.roleId}
+                    onChange={(event) =>
+                      handleUpdateCampaignAssignment(assignment.id, 'roleId', event.target.value)
+                    }
+                  >
+                    <option value="">Select role</option>
+                    {roles.map((role) => (
+                      <option key={role.id} value={role.id}>
+                        {role.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() => handleRemoveCampaignAssignment(assignment.id)}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div className="drawer-actions">
+            <button type="button" className="ghost" onClick={closeCampaignDrawer}>
+              Cancel
+            </button>
+            <button type="submit" className="primary">
+              {campaignDrawer.mode === 'edit' ? 'Save changes' : 'Create campaign'}
+            </button>
+          </div>
+        </form>
+      </RecordDrawer>
+    </div>
+  )
+}
+
+function StandardListView({
+  entityName,
+  columns,
+  records,
+  onCreate,
+  onEdit,
+  onDelete,
+  emptyMessage
+}) {
+  const [visibleColumnIds, setVisibleColumnIds] = useState(() =>
+    columns
+      .filter((column) => column.defaultVisible !== false)
+      .map((column) => column.id)
+  )
+  const [columnMenuOpen, setColumnMenuOpen] = useState(false)
+
+  useEffect(() => {
+    setVisibleColumnIds((previous) => {
+      const existing = previous.filter((columnId) => columns.some((column) => column.id === columnId))
+      const additions = columns
+        .filter((column) => column.defaultVisible !== false && !existing.includes(column.id))
+        .map((column) => column.id)
+      const next = [...existing, ...additions]
+      if (next.length === 0 && columns.length > 0) {
+        return [columns[0].id]
+      }
+      return next
+    })
+  }, [columns])
+
+  const toggleColumnVisibility = (columnId) => {
+    setVisibleColumnIds((previous) => {
+      const isVisible = previous.includes(columnId)
+      if (isVisible) {
+        const remaining = previous.filter((id) => id !== columnId)
+        return remaining.length > 0 ? remaining : previous
+      }
+      return [...previous, columnId]
+    })
+  }
+
+  const renderCellValue = (column, record) => {
+    if (typeof column.accessor === 'function') {
+      return column.accessor(record)
+    }
+    if (column.id in record) {
+      return record[column.id]
+    }
+    return '—'
+  }
+
+  const visibleColumns = columns.filter((column) => visibleColumnIds.includes(column.id))
+
+  return (
+    <section className="standard-list">
+      <header className="list-header">
+        <div>
+          <h2>{entityName} directory</h2>
+          <p>Configure and orchestrate {entityName.toLowerCase()}s for the entire platform.</p>
+        </div>
+
+        <div className="list-actions">
+          <div className="column-visibility">
+            <button
+              type="button"
+              className="ghost"
+              onClick={() => setColumnMenuOpen((open) => !open)}
+              aria-haspopup="true"
+              aria-expanded={columnMenuOpen}
+            >
+              Columns
+            </button>
+            {columnMenuOpen && (
+              <div className="column-menu" role="menu">
+                {columns.map((column) => (
+                  <label key={column.id} className="checkbox-option">
+                    <input
+                      type="checkbox"
+                      checked={visibleColumnIds.includes(column.id)}
+                      onChange={() => toggleColumnVisibility(column.id)}
+                    />
+                    <span>{column.label}</span>
+                  </label>
                 ))}
-              </ul>
+              </div>
             )}
           </div>
-        </section>
-      </main>
 
-      {(statusMessage || errorMessage) && (
-        <div className={`message ${errorMessage ? 'error' : 'success'}`} role="status">
-          {errorMessage || statusMessage}
+          {onCreate && (
+            <button type="button" className="primary" onClick={onCreate}>
+              New {entityName.toLowerCase()}
+            </button>
+          )}
+        </div>
+      </header>
+
+      {records.length === 0 ? (
+        <div className="empty-state">
+          <h3>No {entityName.toLowerCase()}s yet</h3>
+          <p>{emptyMessage}</p>
+        </div>
+      ) : (
+        <div className="table-container">
+          <table>
+            <thead>
+              <tr>
+                {visibleColumns.map((column) => (
+                  <th key={column.id} scope="col">
+                    {column.label}
+                  </th>
+                ))}
+                {(onEdit || onDelete) && <th scope="col" className="actions-header">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {records.map((record) => (
+                <tr key={record.id}>
+                  {visibleColumns.map((column) => (
+                    <td key={column.id}>{renderCellValue(column, record)}</td>
+                  ))}
+                  {(onEdit || onDelete) && (
+                    <td className="row-actions">
+                      {onEdit && (
+                        <button type="button" className="ghost" onClick={() => onEdit(record)}>
+                          Edit
+                        </button>
+                      )}
+                      {onDelete && (
+                        <button
+                          type="button"
+                          className="ghost destructive"
+                          onClick={() => onDelete(record.id)}
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
+    </section>
+  )
+}
+
+function RecordDrawer({ open, title, onClose, children }) {
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="drawer-layer">
+      <div className="drawer-overlay" onClick={onClose} />
+      <aside className="record-drawer" role="dialog" aria-modal="true">
+        <header className="drawer-header">
+          <h3>{title}</h3>
+          <button type="button" className="ghost" onClick={onClose}>
+            Close
+          </button>
+        </header>
+        <div className="drawer-body">{children}</div>
+      </aside>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a platform admin app shell with sidebar navigation, breadcrumbs, and role-aware access control
- implement reusable list views with column visibility controls and drawer-based create/edit workflows
- scaffold user, role, and campaign management flows with local data and cleanup helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41705f140832e9f79440da27c7c57