### PR TITLE
Add token-based authentication and secure login endpoint

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -3,5 +3,7 @@ import 'dotenv/config';
 export const cfg = {
   port: process.env.PORT || 3000,
   dbUrl: process.env.DATABASE_URL,
-  env: process.env.NODE_ENV || 'development'
+  env: process.env.NODE_ENV || 'development',
+  jwtSecret: process.env.JWT_SECRET || 'dev-secret-change-me',
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1h'
 };

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,46 @@
+import { User } from '../models/index.js';
+import { verifyPassword } from '../utils/password.js';
+import { generateToken } from '../utils/token.js';
+
+const sanitizeUser = (user) => {
+  if (!user) return null;
+  const plain = user.get({ plain: true });
+  delete plain.password_hash;
+  return plain;
+};
+
+export const login = async (req, res) => {
+  try {
+    const { username, email, password } = req.body;
+
+    if ((!username && !email) || !password) {
+      return res.status(400).json({
+        success: false,
+        message: 'username or email and password are required'
+      });
+    }
+
+    const where = username ? { username } : { email };
+    const user = await User.findOne({ where });
+
+    if (!user || !user.active) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const passwordMatches = await verifyPassword(password, user.password_hash);
+
+    if (!passwordMatches) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const token = generateToken(user.id);
+
+    res.json({
+      success: true,
+      token,
+      data: sanitizeUser(user)
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,0 +1,27 @@
+import { User } from '../models/index.js';
+import { verifyToken } from '../utils/token.js';
+
+export const authenticateToken = async (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+
+  if (!token) {
+    return res.status(401).json({ success: false, message: 'Authorization token missing' });
+  }
+
+  try {
+    const payload = verifyToken(token);
+    const user = await User.findByPk(payload.sub, {
+      attributes: ['id', 'username', 'email', 'active']
+    });
+
+    if (!user || !user.active) {
+      return res.status(401).json({ success: false, message: 'User is not authorized' });
+    }
+
+    req.user = user.get({ plain: true });
+    next();
+  } catch (error) {
+    return res.status(401).json({ success: false, message: 'Invalid or expired token' });
+  }
+};

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { login } from '../controllers/authController.js';
+
+const router = Router();
+
+router.post('/login', login);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,8 @@ import cors from 'cors';
 import { sequelize } from './models/index.js';
 import { cfg } from './config/env.js';
 import apiRoutes from './routes/index.js';
+import authRoutes from './routes/authRoutes.js';
+import { authenticateToken } from './middleware/authMiddleware.js';
 
 const app = express();
 
@@ -28,7 +30,8 @@ app.use(cors({
 app.use(express.json());
 
 // --- Routes ---
-app.use('/api', apiRoutes);
+app.use('/api/auth', authRoutes);
+app.use('/api', authenticateToken, apiRoutes);
 
 app.get('/', (req, res) => res.send('DnD_app backend running'));
 

--- a/backend/src/utils/password.js
+++ b/backend/src/utils/password.js
@@ -1,0 +1,42 @@
+import crypto from 'node:crypto';
+
+const ITERATIONS = 310000;
+const KEY_LENGTH = 32;
+const DIGEST = 'sha256';
+
+const pbkdf2Async = (password, salt, iterations, keyLength) =>
+  new Promise((resolve, reject) => {
+    crypto.pbkdf2(password, salt, iterations, keyLength, DIGEST, (err, derivedKey) => {
+      if (err) return reject(err);
+      resolve(derivedKey);
+    });
+  });
+
+export const hashPassword = async (password) => {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derivedKey = await pbkdf2Async(password, salt, ITERATIONS, KEY_LENGTH);
+  return `${ITERATIONS}:${KEY_LENGTH}:${salt}:${derivedKey.toString('hex')}`;
+};
+
+export const verifyPassword = async (password, storedHash) => {
+  if (!storedHash) return false;
+  const parts = storedHash.split(':');
+  if (parts.length !== 4) return false;
+
+  const [iterStr, keyLenStr, salt, storedKeyHex] = parts;
+  const iterations = Number.parseInt(iterStr, 10);
+  const keyLength = Number.parseInt(keyLenStr, 10);
+
+  if (!iterations || !keyLength || !salt || !storedKeyHex) return false;
+
+  try {
+    const derivedKey = await pbkdf2Async(password, salt, iterations, keyLength);
+    const storedKey = Buffer.from(storedKeyHex, 'hex');
+    if (storedKey.length !== derivedKey.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(storedKey, derivedKey);
+  } catch (error) {
+    return false;
+  }
+};

--- a/backend/src/utils/token.js
+++ b/backend/src/utils/token.js
@@ -1,0 +1,86 @@
+import crypto from 'node:crypto';
+import { cfg } from '../config/env.js';
+
+const base64UrlEncode = (input) =>
+  Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+const base64UrlDecode = (input) => {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4;
+  const padded = normalized + (padding ? '='.repeat(4 - padding) : '');
+  return Buffer.from(padded, 'base64');
+};
+
+const createSignature = (header, payload, secret) =>
+  base64UrlEncode(crypto.createHmac('sha256', secret).update(`${header}.${payload}`).digest());
+
+const parseExpiresIn = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  const fallback = 3600; // 1 hour
+  if (!value || typeof value !== 'string') {
+    return fallback;
+  }
+
+  const match = value.trim().match(/^(\d+)([smhd])?$/i);
+  if (!match) {
+    return fallback;
+  }
+
+  const amount = Number.parseInt(match[1], 10);
+  const unit = (match[2] || 's').toLowerCase();
+  const multipliers = { s: 1, m: 60, h: 3600, d: 86400 };
+
+  return amount * (multipliers[unit] || 1);
+};
+
+export const generateToken = (subject) => {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const expiresInSeconds = parseExpiresIn(cfg.jwtExpiresIn);
+  const payloadBody = {
+    sub: subject,
+    exp: Math.floor(Date.now() / 1000) + expiresInSeconds
+  };
+  const payload = base64UrlEncode(JSON.stringify(payloadBody));
+  const signature = createSignature(header, payload, cfg.jwtSecret);
+  return `${header}.${payload}.${signature}`;
+};
+
+export const verifyToken = (token) => {
+  if (typeof token !== 'string') {
+    throw new Error('Invalid token');
+  }
+
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid token');
+  }
+
+  const [headerPart, payloadPart, signature] = parts;
+  const expectedSignature = createSignature(headerPart, payloadPart, cfg.jwtSecret);
+
+  const signatureBuffer = Buffer.from(signature);
+  const expectedSignatureBuffer = Buffer.from(expectedSignature);
+
+  if (
+    signatureBuffer.length !== expectedSignatureBuffer.length ||
+    !crypto.timingSafeEqual(signatureBuffer, expectedSignatureBuffer)
+  ) {
+    throw new Error('Invalid token');
+  }
+
+  const payloadJson = base64UrlDecode(payloadPart).toString('utf8');
+  const payload = JSON.parse(payloadJson);
+
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    throw new Error('Token expired');
+  }
+
+  return payload;
+};


### PR DESCRIPTION
## Summary
- add configuration support for signing tokens and tracking expiry
- introduce PBKDF2-based password hashing utilities, login controller, and authentication middleware
- protect existing API routes behind bearer token checks and hide stored password hashes from responses

## Testing
- node - <<'NODE'
- node - <<'NODE'

------
https://chatgpt.com/codex/tasks/task_e_68e4228ff6c8832e85f5ee1ac762780a