### PR TITLE
Add login experience and profile logout controls

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -180,6 +180,14 @@
   gap: 1rem;
 }
 
+.profile-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .profile-header h2 {
   margin: 0;
   font-size: 1.75rem;
@@ -511,6 +519,173 @@ button.ghost.destructive {
   text-align: center;
   border: 1px dashed rgba(148, 163, 184, 0.5);
   color: #475569;
+}
+
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), rgba(15, 23, 42, 0.95));
+}
+
+.login-card {
+  width: min(440px, 100%);
+  background: rgba(248, 250, 252, 0.95);
+  backdrop-filter: blur(12px);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  color: #0f172a;
+}
+
+.login-card-header h1 {
+  margin: 0.75rem 0 0.25rem;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.login-card-header p {
+  margin: 0;
+  color: #475569;
+}
+
+.login-brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.login-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.login-form-field label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.login-form-field input {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form-field input:focus-visible {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.75);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.login-form-field input[aria-invalid='true'] {
+  border-color: rgba(220, 38, 38, 0.65);
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.2);
+}
+
+.field-error {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #b91c1c;
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  color: #991b1b;
+  font-weight: 600;
+}
+
+.login-examples {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.login-examples h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.login-examples-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-examples-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 250, 252, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.login-example-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.login-example-credentials {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.login-example-credentials span {
+  display: flex;
+  gap: 0.35rem;
+  align-items: baseline;
+}
+
+.login-example-credentials code {
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.45rem;
+  font-size: 0.85rem;
+}
+
+button.primary.full-width {
+  width: 100%;
+  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 2rem;
+  }
 }
 
 .drawer-layer {


### PR DESCRIPTION
## Summary
- add persisted session management that validates credentials and redirects unauthenticated visitors to the login page
- build a dedicated login screen with helpful messaging, validation, and demo credentials
- expose a logout action from the user profile and refresh supporting styles for the new views

## Testing
- npm run lint --prefix frontend
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e4250ecb30832eaeb0c9ae30aef490