### PR TITLE
Refine navigation UI and fix record drawer hooks

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -29,33 +29,68 @@
 
 .sidebar-header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-}
-
-.sidebar-header .brand-mark {
-  font-size: 1.4rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  transition: opacity 0.2s ease, max-height 0.2s ease;
-}
-
-.sidebar-header .brand-subtitle {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: rgba(241, 245, 249, 0.78);
-  transition: opacity 0.2s ease, max-height 0.2s ease;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .sidebar-close {
   display: none;
-  border: none;
+  font-size: 1.45rem;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
   background: transparent;
+  border: none;
   color: inherit;
-  font-size: 1.5rem;
-  line-height: 1;
   cursor: pointer;
+  font-size: 1.3rem;
+  line-height: 1;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.45);
+  outline-offset: 2px;
+}
+
+.sidebar-pin-toggle {
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.sidebar-pin-toggle span {
+  pointer-events: none;
+}
+
+.sidebar-pin-toggle.active {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.18);
+}
+
+.sidebar-pin-toggle.active:hover,
+.sidebar-pin-toggle.active:focus-visible {
+  background: rgba(250, 204, 21, 0.24);
+}
+
+.sidebar-close {
+  display: none;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.sidebar-close:hover,
+.sidebar-close:focus-visible {
+  color: #f8fafc;
 }
 
 .sidebar-nav {
@@ -109,33 +144,10 @@
   color: #f8fafc;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
 }
-
-.sidebar-footer {
-  margin-top: auto;
-}
-
-.sidebar-pin-toggle {
-  width: 100%;
-  display: inline-flex;
-  justify-content: center;
-  border-radius: 0.75rem;
-  padding: 0.6rem 0.85rem;
-}
-
-.sidebar-pin-toggle.active {
-  background: rgba(148, 163, 184, 0.15);
-}
-
-.shell-sidebar.sidebar-floating.sidebar-collapsed .brand-mark,
-.shell-sidebar.sidebar-floating.sidebar-collapsed .brand-subtitle,
-.shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-label,
-.shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-footer {
+.shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-label {
   opacity: 0;
   max-height: 0;
   pointer-events: none;
-}
-
-.shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-label {
   width: 0;
 }
 
@@ -203,8 +215,38 @@
   outline-offset: 2px;
 }
 
-.header-primary > div {
+.header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
   min-width: 0;
+  align-items: flex-start;
+}
+
+.header-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.brand-mark {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.brand-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.header-module {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  width: 100%;
 }
 
 .header-actions {
@@ -258,13 +300,13 @@
 }
 
 .module-title {
-  margin: 0.5rem 0 0;
+  margin: 0;
   font-size: 2rem;
   font-weight: 700;
 }
 
 .module-description {
-  margin-top: 0.5rem;
+  margin: 0;
   max-width: 42rem;
   color: #475569;
   line-height: 1.6;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -763,15 +763,22 @@ function App() {
         onMouseLeave={handleSidebarMouseLeave}
       >
         <div className="sidebar-header">
-          <div>
-            <div className="brand-mark">DnD Platform</div>
-            <p className="brand-subtitle">Orchestrate adventures with confidence.</p>
-          </div>
           <button
             type="button"
-            className="ghost sidebar-close"
+            className={`icon-button sidebar-pin-toggle${sidebarPinned ? ' active' : ''}`}
+            onClick={() => setSidebarPinned((prev) => !prev)}
+            aria-pressed={sidebarPinned}
+            aria-label={sidebarPinned ? 'Unpin sidebar' : 'Pin sidebar'}
+            title={sidebarPinned ? 'Unpin sidebar' : 'Pin sidebar'}
+          >
+            <span aria-hidden="true">{sidebarPinned ? '📌' : '📍'}</span>
+          </button>
+          <button
+            type="button"
+            className="icon-button sidebar-close"
             onClick={() => setSidebarMobileOpen(false)}
             aria-label="Close navigation"
+            title="Close navigation"
           >
             ×
           </button>
@@ -802,16 +809,6 @@ function App() {
             )
           })}
         </nav>
-        <div className="sidebar-footer">
-          <button
-            type="button"
-            className={`ghost sidebar-pin-toggle${sidebarPinned ? ' active' : ''}`}
-            onClick={() => setSidebarPinned((prev) => !prev)}
-            aria-pressed={sidebarPinned}
-          >
-            {sidebarPinned ? 'Unpin sidebar' : 'Pin sidebar'}
-          </button>
-        </div>
       </aside>
       {showSidebarBackdrop && (
         <button
@@ -834,17 +831,23 @@ function App() {
             >
               ☰
             </button>
-            <div>
-              <nav className="breadcrumbs" aria-label="Breadcrumb">
-                {breadcrumbs.map((item, index) => (
-                  <span key={item} className="breadcrumb-item">
-                    {item}
-                    {index < breadcrumbs.length - 1 && <span aria-hidden="true">›</span>}
-                  </span>
-                ))}
-              </nav>
-              <h1 className="module-title">{breadcrumbs[breadcrumbs.length - 1]}</h1>
-              {moduleDescription && <p className="module-description">{moduleDescription}</p>}
+            <div className="header-info">
+              <div className="header-brand">
+                <span className="brand-mark">DnD Platform</span>
+                <p className="brand-subtitle">Orchestrate adventures with confidence.</p>
+              </div>
+              <div className="header-module">
+                <nav className="breadcrumbs" aria-label="Breadcrumb">
+                  {breadcrumbs.map((item, index) => (
+                    <span key={item} className="breadcrumb-item">
+                      {item}
+                      {index < breadcrumbs.length - 1 && <span aria-hidden="true">›</span>}
+                    </span>
+                  ))}
+                </nav>
+                <h1 className="module-title">{breadcrumbs[breadcrumbs.length - 1]}</h1>
+                {moduleDescription && <p className="module-description">{moduleDescription}</p>}
+              </div>
             </div>
           </div>
           <div className="header-actions">
@@ -923,7 +926,6 @@ function App() {
 
               {activeModuleId === 'campaigns' && (
                 <CampaignsPage
-                  campaigns={campaigns}
                   accessibleCampaigns={accessibleCampaigns}
                   onSaveCampaign={handleSaveCampaign}
                   onDeleteCampaign={handleDeleteCampaign}
@@ -1176,7 +1178,6 @@ function WorldPage({ worlds, onSaveWorld, onDeleteWorld }) {
 }
 
 function CampaignsPage({
-  campaigns,
   accessibleCampaigns,
   onSaveCampaign,
   onDeleteCampaign,
@@ -2864,9 +2865,9 @@ function RecordDrawer({ open, title, onClose, actions, children }) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [open, onClose])
 
-  if (!open) return null
-
   const headingId = useMemo(() => newId('drawer-title'), [])
+
+  if (!open) return null
 
   return (
     <div className="drawer-layer">


### PR DESCRIPTION
## Summary
- replace the sidebar pin action with an icon control in the header and move platform branding into the main header bar
- restyle the header to accommodate the new branding layout and icon buttons
- ensure the record drawer keeps a stable hook order and clean up unused campaign props

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4344f6330832eb519dbf52f35fb3c