### PR TITLE
Restyle shell with ServiceNow-inspired layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,19 +1,32 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app-shell {
   display: flex;
   min-height: 100vh;
-  background: linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 100%);
+  background: linear-gradient(180deg, #071826 0%, #102a43 40%, #0f172a 60%, #102a43 100%);
   color: #0f172a;
 }
 
 .shell-sidebar {
   width: 264px;
-  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
-  color: #f8fafc;
+  background: linear-gradient(180deg, #031422 0%, #06263a 100%);
+  color: #e2e8f0;
   display: flex;
   flex-direction: column;
   padding: 1.75rem 1.5rem;
   gap: 1.5rem;
-  box-shadow: 0 0 32px rgba(15, 23, 42, 0.25);
+  box-shadow: 0 20px 40px rgba(2, 12, 27, 0.35);
+  border-right: 1px solid rgba(148, 163, 184, 0.12);
   z-index: 12;
   transition: width 0.24s ease, transform 0.24s ease, box-shadow 0.24s ease;
 }
@@ -93,11 +106,53 @@
   color: #f8fafc;
 }
 
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.5rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.sidebar-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.55), rgba(56, 189, 248, 0.5));
+  font-size: 1.35rem;
+  color: #012a36;
+}
+
+.sidebar-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.shell-sidebar.sidebar-collapsed .sidebar-brand {
+  flex-direction: column;
+  align-items: center;
+  padding-inline: 0;
+}
+
+.shell-sidebar.sidebar-collapsed .sidebar-title {
+  display: none;
+}
+
+.shell-sidebar.sidebar-collapsed .sidebar-logo {
+  margin-inline: auto;
+}
+
 .sidebar-nav {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   flex: 1;
+  padding-top: 0.5rem;
 }
 
 .sidebar-empty {
@@ -109,15 +164,17 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.7rem 0.85rem;
-  border-radius: 0.75rem;
+  padding: 0.75rem 0.95rem;
+  border-radius: 0.9rem;
   background: transparent;
-  color: inherit;
+  color: rgba(226, 232, 240, 0.85);
   border: none;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  border-left: 3px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-left-color 0.2s ease;
 }
 
 .sidebar-icon {
@@ -136,13 +193,15 @@
 
 .sidebar-link:hover,
 .sidebar-link:focus-visible {
-  background: rgba(148, 163, 184, 0.15);
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
 }
 
 .sidebar-link.active {
-  background: rgba(96, 165, 250, 0.2);
+  background: rgba(20, 184, 166, 0.22);
   color: #f8fafc;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+  border-left-color: #2dd4bf;
+  box-shadow: inset 0 0 0 1px rgba(45, 212, 191, 0.25), 0 12px 24px rgba(8, 47, 73, 0.25);
 }
 .shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-label {
   opacity: 0;
@@ -175,23 +234,30 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  background: linear-gradient(180deg, rgba(12, 74, 110, 0.35) 0%, rgba(8, 51, 68, 0.5) 18%, #f8fafc 18%, #f8fafc 100%);
 }
 
 .app-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.75rem 2.5rem 1.5rem;
-  background: rgba(248, 250, 252, 0.85);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1rem 2.5rem 1.5rem;
+  background: linear-gradient(180deg, #0b394c 0%, #0b4c41 100%);
+  color: #ecfdf5;
   position: sticky;
   top: 0;
   z-index: 10;
+  box-shadow: 0 22px 48px rgba(2, 13, 31, 0.45);
 }
 
-.header-primary {
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.brand-group {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -199,59 +265,88 @@
 }
 
 .sidebar-trigger {
-  display: none;
-  border: none;
-  background: transparent;
-  font-size: 1.5rem;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(94, 234, 212, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: #ecfdf5;
+  font-size: 1.4rem;
   cursor: pointer;
-  color: #0f172a;
-  padding: 0.25rem;
-  border-radius: 0.5rem;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar-trigger:hover {
+  background: rgba(15, 23, 42, 0.5);
+  border-color: rgba(94, 234, 212, 0.55);
+  transform: translateY(-1px);
 }
 
 .sidebar-trigger:focus-visible {
-  outline: 2px solid rgba(96, 165, 250, 0.6);
-  outline-offset: 2px;
+  outline: 2px solid rgba(125, 211, 252, 0.7);
+  outline-offset: 3px;
 }
 
-.header-info {
+.brand-identity {
   display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 0.85rem;
   min-width: 0;
-  align-items: flex-start;
 }
 
-.header-brand {
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #34d399, #0ea5e9);
+  color: #02323e;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.brand-logo span {
+  font-size: 1rem;
+}
+
+.brand-copy {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.1rem;
+  min-width: 0;
 }
 
-.brand-mark {
-  font-size: 1.4rem;
+.brand-title {
+  font-size: 1.1rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .brand-subtitle {
   margin: 0;
-  font-size: 0.9rem;
-  color: rgba(15, 23, 42, 0.65);
+  font-size: 0.85rem;
+  color: rgba(236, 253, 245, 0.75);
 }
 
 .header-module {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.5rem;
   min-width: 0;
   width: 100%;
+  border-top: 1px solid rgba(236, 253, 245, 0.18);
+  padding-top: 1rem;
 }
 
 .header-actions {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 1.5rem;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -260,7 +355,7 @@
 .context-switchers {
   display: flex;
   gap: 1rem;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .context-select {
@@ -268,23 +363,36 @@
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.875rem;
+  color: rgba(236, 253, 245, 0.9);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.context-select span {
+  font-weight: 600;
 }
 
 .context-select select {
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.6);
+  border: 1px solid rgba(94, 234, 212, 0.35);
   padding: 0.55rem 0.75rem;
   font-size: 0.95rem;
-  background: #ffffff;
-  color: #0f172a;
+  background: rgba(15, 118, 110, 0.25);
+  color: #ecfdf5;
   min-width: 12rem;
+  box-shadow: inset 0 0 0 1px rgba(45, 212, 191, 0.2);
+}
+
+.context-select select:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.75);
+  outline-offset: 2px;
 }
 
 .breadcrumbs {
   display: flex;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: #475569;
+  color: rgba(226, 245, 239, 0.75);
   align-items: center;
 }
 
@@ -296,58 +404,89 @@
 
 .breadcrumb-item span[aria-hidden='true'] {
   margin: 0 0.25rem;
-  color: rgba(71, 85, 105, 0.6);
+  color: rgba(226, 245, 239, 0.5);
 }
 
 .module-title {
   margin: 0;
-  font-size: 2rem;
+  font-size: 2.05rem;
   font-weight: 700;
+  color: #ecfdf5;
+  letter-spacing: 0.01em;
 }
 
 .module-description {
   margin: 0;
   max-width: 42rem;
-  color: #475569;
+  color: rgba(226, 245, 239, 0.85);
   line-height: 1.6;
 }
 
 .current-user-button {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.25rem;
-  color: #0f172a;
-  background: transparent;
-  border: none;
-  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #ecfdf5;
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(236, 253, 245, 0.35);
+  padding: 0.45rem 0.85rem 0.45rem 0.45rem;
+  border-radius: 9999px;
   cursor: pointer;
-  text-align: right;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .current-user-button:hover,
 .current-user-button:focus-visible {
-  color: #1d4ed8;
+  background: rgba(15, 23, 42, 0.48);
+  border-color: rgba(236, 253, 245, 0.55);
+  transform: translateY(-1px);
 }
 
 .current-user-button:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.3);
+  outline: 2px solid rgba(34, 211, 238, 0.65);
   outline-offset: 4px;
+}
+
+.user-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.85), rgba(56, 189, 248, 0.85));
+  color: #022c22;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.user-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
 }
 
 .user-name {
   font-weight: 600;
+  color: inherit;
 }
 
 .user-role {
-  font-size: 0.875rem;
-  color: #475569;
+  font-size: 0.85rem;
+  color: rgba(226, 245, 239, 0.75);
 }
 
 .module-content {
   flex: 1;
-  padding: 2rem 2.5rem 3rem;
+  padding: 2.25rem 2.75rem 3.5rem;
   min-width: 0;
+  background: #f8fafc;
+  border-top-left-radius: 1.75rem;
+  border-top-right-radius: 1.75rem;
+  box-shadow: 0 -18px 48px rgba(15, 23, 42, 0.18);
+  color: #0f172a;
 }
 
 .platform-admin {
@@ -1182,12 +1321,25 @@ button.primary.full-width {
     display: none;
   }
 
-  .sidebar-trigger {
-    display: inline-flex;
+  .app-header {
+    padding: 1.25rem 1.75rem 1.5rem;
+    gap: 1rem;
+  }
+
+  .header-bar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .brand-group {
+    justify-content: space-between;
   }
 
   .header-actions {
-    align-items: flex-end;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
     gap: 1rem;
   }
 
@@ -1195,37 +1347,59 @@ button.primary.full-width {
     flex-direction: column;
     align-items: stretch;
     gap: 0.75rem;
+    width: 100%;
+  }
+
+  .context-select {
+    text-transform: none;
+    letter-spacing: 0.02em;
   }
 
   .context-select select {
     min-width: unset;
+    width: 100%;
+  }
+
+  .current-user-button {
+    align-self: flex-end;
   }
 
   .module-content {
-    padding: 1.75rem 1.5rem 2.5rem;
+    padding: 1.75rem 1.75rem 2.5rem;
+    border-top-left-radius: 1.5rem;
+    border-top-right-radius: 1.5rem;
   }
 }
 
 @media (max-width: 640px) {
   .app-header {
-    padding: 1.5rem 1.25rem 1rem;
+    padding: 1.25rem 1.25rem 1.25rem;
   }
 
-  .header-primary {
-    align-items: flex-start;
+  .brand-group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
   }
 
   .header-actions {
-    width: 100%;
+    flex-direction: column;
     align-items: stretch;
   }
 
   .current-user-button {
-    align-items: flex-start;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .user-meta {
+    align-items: flex-end;
   }
 
   .module-content {
     padding: 1.5rem 1.25rem 2.5rem;
+    border-top-left-radius: 1.25rem;
+    border-top-right-radius: 1.25rem;
   }
 
   .module-title {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -283,6 +283,17 @@ function App() {
   const currentUserStatus = resolvedCurrentUser?.status ?? 'Active'
   const currentUserTitle = currentAccountProfile?.title ?? 'Adventurer'
   const currentUserPreferences = currentAccountProfile?.preferences ?? {}
+  const currentUserInitials = useMemo(() => {
+    const source = (currentUserDisplayName || '').trim()
+    if (!source) return 'AD'
+    const segments = source.split(/\s+/).filter(Boolean)
+    if (segments.length === 0) return 'AD'
+    const initials = segments
+      .slice(0, 2)
+      .map((segment) => segment.charAt(0).toUpperCase())
+      .join('')
+    return initials || 'AD'
+  }, [currentUserDisplayName])
   const currentUserCapabilityRoles = useMemo(() => {
     const capabilitySet = new Set(currentAccountProfile?.capabilityRoles ?? [])
 
@@ -783,6 +794,12 @@ function App() {
             ×
           </button>
         </div>
+        <div className="sidebar-brand" aria-label="DnD platform workspace">
+          <span className="sidebar-logo" aria-hidden="true">
+            🛡️
+          </span>
+          <span className="sidebar-title">Planar Service Hub</span>
+        </div>
         <nav className="sidebar-nav">
           {sidebarModules.length === 0 && <p className="sidebar-empty">No modules available for your role.</p>}
           {sidebarModules.map((module) => {
@@ -821,82 +838,93 @@ function App() {
 
       <div className="shell-main">
         <header className="app-header">
-          <div className="header-primary">
-            <button
-              type="button"
-              className="sidebar-trigger"
-              onClick={() => setSidebarMobileOpen(true)}
-              aria-label="Open navigation"
-              aria-expanded={sidebarMobileOpen}
-            >
-              ☰
-            </button>
-            <div className="header-info">
-              <div className="header-brand">
-                <span className="brand-mark">DnD Platform</span>
-                <p className="brand-subtitle">Orchestrate adventures with confidence.</p>
+          <div className="header-bar">
+            <div className="brand-group">
+              <button
+                type="button"
+                className="sidebar-trigger"
+                onClick={() => setSidebarMobileOpen(true)}
+                aria-label="Open navigation"
+                aria-expanded={sidebarMobileOpen}
+              >
+                <span className="sr-only">Open navigation</span>
+                <span aria-hidden="true">☰</span>
+              </button>
+              <div className="brand-identity">
+                <div className="brand-logo" aria-hidden="true">
+                  <span>SN</span>
+                </div>
+                <div className="brand-copy">
+                  <span className="brand-title">Planar Service Hub</span>
+                  <span className="brand-subtitle">Adventuring operations workspace</span>
+                </div>
               </div>
-              <div className="header-module">
-                <nav className="breadcrumbs" aria-label="Breadcrumb">
-                  {breadcrumbs.map((item, index) => (
-                    <span key={item} className="breadcrumb-item">
-                      {item}
-                      {index < breadcrumbs.length - 1 && <span aria-hidden="true">›</span>}
-                    </span>
-                  ))}
-                </nav>
-                <h1 className="module-title">{breadcrumbs[breadcrumbs.length - 1]}</h1>
-                {moduleDescription && <p className="module-description">{moduleDescription}</p>}
+            </div>
+            <div className="header-actions">
+              <div className="context-switchers" aria-label="Active context selection">
+                <label className="context-select">
+                  <span>Campaign</span>
+                  <select
+                    value={appContext.campaignId}
+                    onChange={(event) =>
+                      setAppContext((prev) => ({ ...prev, campaignId: event.target.value }))
+                    }
+                  >
+                    <option value="">No campaign selected</option>
+                    {accessibleCampaigns.map((campaign) => (
+                      <option key={campaign.id} value={campaign.id}>
+                        {campaign.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="context-select">
+                  <span>Character</span>
+                  <select
+                    value={appContext.characterId}
+                    onChange={(event) =>
+                      setAppContext((prev) => ({ ...prev, characterId: event.target.value }))
+                    }
+                  >
+                    <option value="">No character selected</option>
+                    {myCharacters.map((character) => (
+                      <option key={character.id} value={character.id}>
+                        {character.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               </div>
+              <button
+                type="button"
+                className="current-user-button"
+                onClick={() => {
+                  setProfileOpen(true)
+                  setSidebarMobileOpen(false)
+                }}
+                aria-label="Open my profile"
+              >
+                <span className="user-avatar" aria-hidden="true">
+                  {currentUserInitials}
+                </span>
+                <span className="user-meta">
+                  <span className="user-name">{currentUserDisplayName}</span>
+                  <span className="user-role">{currentUserRoleNames.join(', ')}</span>
+                </span>
+              </button>
             </div>
           </div>
-          <div className="header-actions">
-            <div className="context-switchers" aria-label="Active context selection">
-              <label className="context-select">
-                <span>Campaign</span>
-                <select
-                  value={appContext.campaignId}
-                  onChange={(event) =>
-                    setAppContext((prev) => ({ ...prev, campaignId: event.target.value }))
-                  }
-                >
-                  <option value="">No campaign selected</option>
-                  {accessibleCampaigns.map((campaign) => (
-                    <option key={campaign.id} value={campaign.id}>
-                      {campaign.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="context-select">
-                <span>Character</span>
-                <select
-                  value={appContext.characterId}
-                  onChange={(event) =>
-                    setAppContext((prev) => ({ ...prev, characterId: event.target.value }))
-                  }
-                >
-                  <option value="">No character selected</option>
-                  {myCharacters.map((character) => (
-                    <option key={character.id} value={character.id}>
-                      {character.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
-            <button
-              type="button"
-              className="current-user-button"
-              onClick={() => {
-                setProfileOpen(true)
-                setSidebarMobileOpen(false)
-              }}
-              aria-label="Open my profile"
-            >
-              <span className="user-name">{currentUserDisplayName}</span>
-              <span className="user-role">{currentUserRoleNames.join(', ')}</span>
-            </button>
+          <div className="header-module">
+            <nav className="breadcrumbs" aria-label="Breadcrumb">
+              {breadcrumbs.map((item, index) => (
+                <span key={item} className="breadcrumb-item">
+                  {item}
+                  {index < breadcrumbs.length - 1 && <span aria-hidden="true">›</span>}
+                </span>
+              ))}
+            </nav>
+            <h1 className="module-title">{breadcrumbs[breadcrumbs.length - 1]}</h1>
+            {moduleDescription && <p className="module-description">{moduleDescription}</p>}
           </div>
         </header>
 


### PR DESCRIPTION
## Summary
- restyled the application shell with a ServiceNow-inspired header bar, contextual selectors, and responsive layout refinements
- added a branded sidebar masthead and avatar initials so the navigation feels cohesive when collapsed or expanded
- refreshed shell styling tokens, gradients, and breakpoints to deliver a carded content area and improved accessibility helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4392b3acc832e9c8c51a449d1c911