### PR TITLE
Rework header layout and sidebar pin

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,9 +12,16 @@
 
 .app-shell {
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
   background: linear-gradient(180deg, #071826 0%, #102a43 40%, #0f172a 60%, #102a43 100%);
   color: #0f172a;
+}
+
+.app-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
 }
 
 .shell-sidebar {
@@ -27,7 +34,7 @@
   gap: 1.5rem;
   box-shadow: 0 20px 40px rgba(2, 12, 27, 0.35);
   border-right: 1px solid rgba(148, 163, 184, 0.12);
-  z-index: 12;
+  z-index: 10;
   transition: width 0.24s ease, transform 0.24s ease, box-shadow 0.24s ease;
 }
 
@@ -82,7 +89,9 @@
   color: rgba(248, 250, 252, 0.85);
 }
 
-.sidebar-pin-toggle span {
+.sidebar-pin-toggle svg {
+  width: 1.35rem;
+  height: 1.35rem;
   pointer-events: none;
 }
 
@@ -216,7 +225,10 @@
 
 .sidebar-backdrop {
   position: fixed;
-  inset: 0;
+  top: var(--app-header-height, 0px);
+  left: 0;
+  right: 0;
+  bottom: 0;
   background: rgba(15, 23, 42, 0.35);
   backdrop-filter: blur(6px);
   border: none;
@@ -246,7 +258,8 @@
   color: #ecfdf5;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 30;
+  width: 100%;
   box-shadow: 0 22px 48px rgba(2, 13, 31, 0.45);
 }
 
@@ -255,39 +268,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-}
-
-.brand-group {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  min-width: 0;
-}
-
-.sidebar-trigger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(94, 234, 212, 0.35);
-  background: rgba(15, 23, 42, 0.35);
-  color: #ecfdf5;
-  font-size: 1.4rem;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
-}
-
-.sidebar-trigger:hover {
-  background: rgba(15, 23, 42, 0.5);
-  border-color: rgba(94, 234, 212, 0.55);
-  transform: translateY(-1px);
-}
-
-.sidebar-trigger:focus-visible {
-  outline: 2px solid rgba(125, 211, 252, 0.7);
-  outline-offset: 3px;
 }
 
 .brand-identity {
@@ -1294,30 +1274,40 @@ button.primary.full-width {
 }
 
 @media (max-width: 960px) {
-  .app-shell {
+  .app-body {
     flex-direction: column;
   }
 
   .shell-sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    transform: translateX(-100%);
-    width: 264px;
-    max-width: 85vw;
-    padding: 2rem 1.5rem;
+    position: static;
+    transform: none !important;
+    width: 100%;
+    max-width: none;
+    padding: 1.75rem 1.5rem;
+    box-shadow: none;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
   }
 
-  .shell-sidebar.sidebar-mobile-open {
-    transform: translateX(0);
+  .shell-sidebar.sidebar-collapsed {
+    width: 100%;
+    padding: 1.75rem 1.5rem;
   }
 
-  .sidebar-close {
-    display: inline-flex;
+  .shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-label {
+    opacity: 1;
+    max-height: none;
+    pointer-events: auto;
+    width: auto;
   }
 
-  .sidebar-pin-toggle {
+  .shell-sidebar.sidebar-floating.sidebar-collapsed .sidebar-icon {
+    margin-inline: 0;
+  }
+
+  .sidebar-close,
+  .sidebar-pin-toggle,
+  .sidebar-backdrop {
     display: none;
   }
 
@@ -1330,10 +1320,6 @@ button.primary.full-width {
     flex-direction: column;
     align-items: stretch;
     gap: 1rem;
-  }
-
-  .brand-group {
-    justify-content: space-between;
   }
 
   .header-actions {
@@ -1376,7 +1362,7 @@ button.primary.full-width {
     padding: 1.25rem 1.25rem 1.25rem;
   }
 
-  .brand-group {
+  .brand-identity {
     flex-direction: column;
     align-items: stretch;
     gap: 0.75rem;


### PR DESCRIPTION
## Summary
- Elevate the global header so it spans the full viewport, rename the workspace to "DND Shared Space," and render navigation beneath it.
- Replace the sidebar pin emoji with an outline icon, hide the toggle when the menu is collapsed, and track header height so overlays sit below it.
- Update responsive styles so the sidebar stays under the header across breakpoints without relying on the removed hamburger trigger.

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e4c591383c832e92001b5ea4cf6ccc