### PR TITLE
Add world association and campaign detail experience improvements

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -484,6 +484,21 @@
   gap: 1rem;
 }
 
+.campaign-card.campaign-card-clickable {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.campaign-card.campaign-card-clickable:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.16);
+}
+
+.campaign-card.campaign-card-clickable:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.7);
+  outline-offset: 4px;
+}
+
 .world-card h3,
 .campaign-card h3,
 .character-card h3 {
@@ -576,11 +591,11 @@
   color: #b45309;
 }
 
-.campaign-party h4 {
+.campaign-group h4 {
   margin: 0 0 0.5rem;
 }
 
-.campaign-party ul {
+.campaign-group ul {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -589,7 +604,7 @@
   gap: 0.5rem;
 }
 
-.campaign-party li {
+.campaign-group ul li {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
@@ -1393,6 +1408,116 @@ button.primary.full-width {
   margin: 0;
   font-size: 0.875rem;
   color: #64748b;
+}
+
+.campaign-record {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.campaign-drawer-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.campaign-record-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 0;
+}
+
+.campaign-record-meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.campaign-record-meta dd {
+  margin: 0.15rem 0 0;
+  color: #0f172a;
+}
+
+.campaign-record-summary {
+  margin: 0;
+  color: #334155;
+  line-height: 1.6;
+}
+
+.campaign-record-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.campaign-record-groups {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.campaign-record-groups section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.campaign-record-groups h4 {
+  margin: 0;
+}
+
+.campaign-record-groups ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.campaign-record-groups ul li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.assignment-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.assignment-table-header {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+}
+
+.assignment-table-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.assignment-table-row select {
+  width: 100%;
+}
+
+.assignment-table-row button {
+  justify-self: end;
+}
+
+.assignment-table-actions {
+  justify-self: end;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
 }
 
 .drawer-subsection {


### PR DESCRIPTION
## Summary
- allow campaigns to be linked to worlds and ensure the worlds module is available to system administrators
- redesign the campaign list and record drawer with DM/party groupings and a streamlined assignment editor
- update the platform admin campaign tools to manage worlds and assignments with compact table styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4cdce1230832e8432e6c3fc73987d