### PR TITLE
Implement client-side routing and profile dropdown

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,6 +16,7 @@
   min-height: 100vh;
   background: linear-gradient(180deg, #071826 0%, #102a43 40%, #0f172a 60%, #102a43 100%);
   color: #0f172a;
+  overflow-x: hidden;
 }
 
 .app-body {
@@ -47,16 +48,11 @@
   box-shadow: none;
 }
 
-.sidebar-header {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.75rem;
-}
-
 .sidebar-close {
   display: none;
   font-size: 1.45rem;
+  margin-left: auto;
+  align-self: flex-end;
 }
 
 .icon-button {
@@ -90,8 +86,8 @@
 }
 
 .sidebar-pin-toggle svg {
-  width: 1.35rem;
-  height: 1.35rem;
+  width: 1.2rem;
+  height: 1.2rem;
   pointer-events: none;
 }
 
@@ -167,6 +163,59 @@
 .sidebar-empty {
   font-size: 0.875rem;
   color: rgba(241, 245, 249, 0.75);
+}
+
+.sidebar-pin-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  border: none;
+  background: transparent;
+  border-radius: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease;
+  margin-bottom: 0.35rem;
+}
+
+.sidebar-pin-inline:hover,
+.sidebar-pin-inline:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
+}
+
+.sidebar-pin-inline:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.45);
+  outline-offset: 2px;
+}
+
+.sidebar-pin-inline.active {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.18);
+}
+
+.sidebar-pin-inline.active:hover,
+.sidebar-pin-inline.active:focus-visible {
+  background: rgba(250, 204, 21, 0.24);
+}
+
+.sidebar-pin-icon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.sidebar-pin-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.shell-sidebar.sidebar-collapsed .sidebar-pin-inline {
+  justify-content: center;
+  padding-inline: 0.5rem;
 }
 
 .sidebar-link {
@@ -266,9 +315,10 @@
 
 .header-bar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
 .brand-identity {
@@ -318,15 +368,20 @@
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
   justify-content: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .context-switchers {
   display: flex;
   gap: 1rem;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .context-select {
@@ -337,6 +392,7 @@
   color: rgba(236, 253, 245, 0.9);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  min-width: 0;
 }
 
 .context-select span {
@@ -350,13 +406,20 @@
   font-size: 0.95rem;
   background: rgba(15, 118, 110, 0.25);
   color: #ecfdf5;
-  min-width: 12rem;
+  min-width: 10rem;
+  max-width: 16rem;
+  width: 100%;
   box-shadow: inset 0 0 0 1px rgba(45, 212, 191, 0.2);
 }
 
 .context-select select:focus-visible {
   outline: 2px solid rgba(14, 165, 233, 0.75);
   outline-offset: 2px;
+}
+
+.current-user-menu {
+  position: relative;
+  min-width: 0;
 }
 
 .current-user-button {
@@ -371,6 +434,7 @@
   cursor: pointer;
   text-align: left;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  max-width: 100%;
 }
 
 .current-user-button:hover,
@@ -403,16 +467,93 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.15rem;
+  min-width: 0;
 }
 
 .user-name {
   font-weight: 600;
   color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14rem;
 }
 
 .user-role {
   font-size: 0.85rem;
   color: rgba(226, 245, 239, 0.75);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14rem;
+}
+
+.profile-dropdown {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(280px, 82vw);
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 42px rgba(8, 47, 73, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 22;
+  color: #e2e8f0;
+}
+
+.profile-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-overview-name {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.profile-overview-role {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.profile-overview-email {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+  word-break: break-word;
+}
+
+.profile-overview-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.profile-overview-title {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.profile-dropdown .status-pill {
+  padding-inline: 0.6rem;
+}
+
+.profile-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.profile-actions .ghost {
+  padding-inline: 0.95rem;
 }
 
 .module-content {
@@ -1329,6 +1470,16 @@ button.primary.full-width {
   }
 }
 
+@media (max-width: 720px) {
+  .brand-copy {
+    display: none;
+  }
+
+  .header-bar {
+    justify-content: center;
+  }
+}
+
 @media (max-width: 640px) {
   .app-header {
     padding: 1rem 1.25rem 1.1rem;
@@ -1549,7 +1700,7 @@ button.primary.full-width {
 .confirm-layer {
   position: fixed;
   inset: 0;
-  z-index: 30;
+  z-index: 80;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- implement client-side path management so main content renders page views by URL and campaign drawers sync with routes
- add profile dropdown menu, reorganize context selectors, and restrict campaign creation to dungeon masters or system administrators
- refresh sidebar pin layout, header responsiveness, and modal layering to tidy the UI on desktop and mobile

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e4d28d4e38832ea7d3f29a9cb947c3