### PR TITLE
Fix character modal state initialisation in campaigns page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1332,15 +1332,6 @@ function WorldPage({ worlds, onSaveWorld, onDeleteWorld }) {
   const [editor, setEditor] = useState({ open: false, mode: 'create', record: null })
   const [form, setForm] = useState({ name: '', tagline: '', description: '' })
   const [confirmState, setConfirmState] = useState({ open: false, record: null })
-  const [characterModal, setCharacterModal] = useState({
-    open: false,
-    ownerId: '',
-    campaignId: '',
-    name: '',
-    className: '',
-    level: 1,
-    ancestry: ''
-  })
 
   const sortedWorlds = useMemo(() => {
     return [...worlds].sort((a, b) => {
@@ -1612,6 +1603,15 @@ function CampaignsPage({
     assignments: []
   })
   const [confirmState, setConfirmState] = useState({ open: false, record: null })
+  const [characterModal, setCharacterModal] = useState({
+    open: false,
+    ownerId: '',
+    campaignId: '',
+    name: '',
+    className: '',
+    level: 1,
+    ancestry: ''
+  })
 
   useEffect(() => {
     if (!canCreateCampaigns) {


### PR DESCRIPTION
## Summary
- remove an unused character modal state from the worlds page component
- initialise the character modal state inside the campaigns page where it is used to prevent runtime reference errors

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e5106245bc832eb400c7036f4fe2d8