### PR TITLE
Add world entity visibility system

### DIFF
--- a/backend/src/controllers/locationController.js
+++ b/backend/src/controllers/locationController.js
@@ -1,0 +1,255 @@
+import {
+  Location,
+  LocationType,
+  LocationVisibility,
+  Organisation,
+
+  Campaign,
+  User
+} from '../models/index.js';
+import {
+  applyWorldScope,
+  buildVisibilityInclude,
+  normalizeVisibilityEntries,
+  resolveDefaultVisibility,
+  syncVisibilityEntries
+} from '../utils/visibility.js';
+
+const locationIncludes = (context) => ([
+  { model: LocationType, as: 'type' },
+  {
+    model: Organisation,
+    as: 'organisations',
+    through: { attributes: [] }
+  },
+  buildVisibilityInclude({
+    context,
+    model: LocationVisibility,
+    as: 'visibility',
+    include: [
+      { model: Campaign, as: 'campaign', attributes: ['id', 'name'] },
+      { model: User, as: 'player', attributes: ['id', 'username'] }
+    ]
+  })
+]);
+
+const ensurePrivileged = (context) => {
+  if (!context) return false;
+  return context.isWorldAdmin || context.isDm;
+};
+
+const loadLocation = async (id, context) => {
+  return Location.findByPk(id, {
+    include: locationIncludes(context)
+  });
+};
+
+export const listLocations = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (context?.restrictAll && !context?.bypassVisibility) {
+      return res.json({ success: true, data: [] });
+    }
+
+    const where = applyWorldScope({}, context);
+
+    const locations = await Location.findAll({
+      where,
+      include: locationIncludes(context),
+      order: [['name', 'ASC']],
+      distinct: true
+    });
+
+    res.json({ success: true, data: locations });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const getLocation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const location = await loadLocation(req.params.id, context);
+    if (!location) {
+      return res.status(404).json({ success: false, message: 'Location not found' });
+    }
+
+    if (!context?.bypassVisibility) {
+      const visibilityMatches = location.visibility?.some((entry) => {
+        if (entry.campaign_id && context?.campaignId && entry.campaign_id === context.campaignId) return true;
+        if (entry.player_id && entry.player_id === context?.playerId) return true;
+        return entry.campaign_id === null && entry.player_id === null;
+      });
+      if (!visibilityMatches) {
+        return res.status(403).json({ success: false, message: 'Location is not visible in this context' });
+      }
+    }
+
+    res.json({ success: true, data: location });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createLocation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to create locations' });
+    }
+
+    const { name, description, summary, worldId, typeId, visibility } = req.body;
+    const effectiveWorldId = worldId || context?.worldId || context?.worldScope?.[0];
+
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+    if (!effectiveWorldId) {
+      return res.status(400).json({ success: false, message: 'worldId is required for locations' });
+    }
+
+    const location = await Location.create({
+      name,
+      description,
+      summary,
+      world_id: effectiveWorldId,
+      type_id: typeId || null,
+      created_by: req.user.id,
+      created_at: new Date(),
+      updated_at: new Date()
+    });
+
+    const visibilityEntries = normalizeVisibilityEntries(visibility?.length ? visibility : resolveDefaultVisibility(context));
+    if (visibilityEntries.length) {
+      await syncVisibilityEntries(LocationVisibility, 'location_id', location.id, visibilityEntries);
+    }
+
+    const hydrated = await loadLocation(location.id, context);
+    res.status(201).json({ success: true, data: hydrated, message: 'Location created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateLocation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to update locations' });
+    }
+
+    const location = await Location.findByPk(req.params.id);
+    if (!location) {
+      return res.status(404).json({ success: false, message: 'Location not found' });
+    }
+
+    const { name, description, summary, typeId, worldId, visibility } = req.body;
+
+    if (typeof name !== 'undefined') location.name = name;
+    if (typeof description !== 'undefined') location.description = description;
+    if (typeof summary !== 'undefined') location.summary = summary;
+    if (typeof typeId !== 'undefined') location.type_id = typeId || null;
+    if (typeof worldId !== 'undefined') location.world_id = worldId || location.world_id;
+    location.updated_at = new Date();
+
+    await location.save();
+
+    if (visibility) {
+      await syncVisibilityEntries(LocationVisibility, 'location_id', location.id, visibility);
+    }
+
+    const hydrated = await loadLocation(location.id, context);
+    res.json({ success: true, data: hydrated, message: 'Location updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteLocation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to delete locations' });
+    }
+
+    const location = await Location.findByPk(req.params.id);
+    if (!location) {
+      return res.status(404).json({ success: false, message: 'Location not found' });
+    }
+
+    await location.destroy();
+    res.json({ success: true, data: null, message: 'Location deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const listLocationTypes = async (_req, res) => {
+  try {
+    const types = await LocationType.findAll({ order: [['name', 'ASC']] });
+    res.json({ success: true, data: types });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createLocationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage location types' });
+    }
+
+    const { name, description } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    const type = await LocationType.create({ name, description, created_at: new Date() });
+    res.status(201).json({ success: true, data: type, message: 'Location type created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateLocationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage location types' });
+    }
+
+    const type = await LocationType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'Location type not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name !== 'undefined') type.name = name;
+    if (typeof description !== 'undefined') type.description = description;
+    await type.save();
+
+    res.json({ success: true, data: type, message: 'Location type updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteLocationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage location types' });
+    }
+
+    const type = await LocationType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'Location type not found' });
+    }
+
+    await type.destroy();
+    res.json({ success: true, data: null, message: 'Location type deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/controllers/npcController.js
+++ b/backend/src/controllers/npcController.js
@@ -1,0 +1,392 @@
+import {
+  Npc,
+  NpcType,
+  NpcVisibility,
+  NpcNote,
+  NpcRelationship,
+  Race,
+  Campaign,
+  User
+} from '../models/index.js';
+import {
+  applyWorldScope,
+  buildVisibilityInclude,
+  normalizeVisibilityEntries,
+  resolveDefaultVisibility,
+  syncVisibilityEntries
+} from '../utils/visibility.js';
+
+const npcListIncludes = (context) => ([
+  { model: NpcType, as: 'type' },
+  { model: Race, as: 'race' },
+  buildVisibilityInclude({
+    context,
+    model: NpcVisibility,
+    as: 'visibility',
+    include: [
+      { model: Campaign, as: 'campaign', attributes: ['id', 'name'] },
+      { model: User, as: 'player', attributes: ['id', 'username'] }
+    ]
+  })
+]);
+
+const npcDetailIncludes = (context) => ([
+  ...npcListIncludes(context),
+  {
+    model: NpcNote,
+    as: 'notes',
+    include: [{ model: User, as: 'author', attributes: ['id', 'username'] }]
+  },
+  {
+    model: NpcRelationship,
+    as: 'relationships',
+    include: [{ model: Npc, as: 'relatedNpc', attributes: ['id', 'name'] }]
+  }
+]);
+
+const ensurePrivileged = (context) => context?.isWorldAdmin || context?.isDm;
+
+const filterNotesForContext = (notes, context) => {
+  if (!Array.isArray(notes)) return [];
+  if (context?.bypassVisibility) {
+    return notes;
+  }
+
+  return notes.filter((note) => {
+    if (note.visibility_level === 'DM') return false;
+    if (note.visibility_level === 'Private') {
+      return note.author_id === context?.playerId;
+    }
+    if (note.visibility_level === 'Party') {
+      return Boolean(context?.campaignId);
+    }
+    return false;
+  });
+};
+
+const loadNpc = async (id, context) => Npc.findByPk(id, {
+  include: npcDetailIncludes(context)
+});
+
+export const listNpcs = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (context?.restrictAll && !context?.bypassVisibility) {
+      return res.json({ success: true, data: [] });
+    }
+
+    const where = applyWorldScope({}, context);
+    const npcs = await Npc.findAll({
+      where,
+      include: npcListIncludes(context),
+      order: [['name', 'ASC']],
+      distinct: true
+    });
+
+    res.json({ success: true, data: npcs });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const getNpc = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const npc = await loadNpc(req.params.id, context);
+    if (!npc) {
+      return res.status(404).json({ success: false, message: 'NPC not found' });
+    }
+
+    if (!context?.bypassVisibility) {
+      const visible = npc.visibility?.some((entry) => {
+        if (entry.campaign_id && context?.campaignId && entry.campaign_id === context.campaignId) return true;
+        if (entry.player_id && entry.player_id === context?.playerId) return true;
+        return entry.campaign_id === null && entry.player_id === null;
+      });
+      if (!visible) {
+        return res.status(403).json({ success: false, message: 'NPC is not visible in this context' });
+      }
+    }
+
+    const plain = npc.get({ plain: true });
+    plain.notes = filterNotesForContext(plain.notes, context);
+    res.json({ success: true, data: plain });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createNpc = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to create NPCs' });
+    }
+
+    const { name, description, demeanor, worldId, typeId, raceId, visibility } = req.body;
+    const effectiveWorldId = worldId || context?.worldId || context?.worldScope?.[0];
+
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+    if (!effectiveWorldId) {
+      return res.status(400).json({ success: false, message: 'worldId is required for NPCs' });
+    }
+
+    const npc = await Npc.create({
+      name,
+      description,
+      demeanor,
+      world_id: effectiveWorldId,
+      type_id: typeId || null,
+      race_id: raceId || null,
+      created_by: req.user.id,
+      created_at: new Date(),
+      updated_at: new Date()
+    });
+
+    const visibilityEntries = normalizeVisibilityEntries(visibility?.length ? visibility : resolveDefaultVisibility(context));
+    if (visibilityEntries.length) {
+      await syncVisibilityEntries(NpcVisibility, 'npc_id', npc.id, visibilityEntries);
+    }
+
+    const hydrated = await loadNpc(npc.id, context);
+    const plain = hydrated.get({ plain: true });
+    plain.notes = filterNotesForContext(plain.notes, context);
+    res.status(201).json({ success: true, data: plain, message: 'NPC created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateNpc = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to update NPCs' });
+    }
+
+    const npc = await Npc.findByPk(req.params.id);
+    if (!npc) {
+      return res.status(404).json({ success: false, message: 'NPC not found' });
+    }
+
+    const { name, description, demeanor, worldId, typeId, raceId, visibility } = req.body;
+
+    if (typeof name !== 'undefined') npc.name = name;
+    if (typeof description !== 'undefined') npc.description = description;
+    if (typeof demeanor !== 'undefined') npc.demeanor = demeanor;
+    if (typeof worldId !== 'undefined') npc.world_id = worldId || npc.world_id;
+    if (typeof typeId !== 'undefined') npc.type_id = typeId || null;
+    if (typeof raceId !== 'undefined') npc.race_id = raceId || null;
+    npc.updated_at = new Date();
+
+    await npc.save();
+
+    if (visibility) {
+      await syncVisibilityEntries(NpcVisibility, 'npc_id', npc.id, visibility);
+    }
+
+    const hydrated = await loadNpc(npc.id, context);
+    const plain = hydrated.get({ plain: true });
+    plain.notes = filterNotesForContext(plain.notes, context);
+    res.json({ success: true, data: plain, message: 'NPC updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteNpc = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to delete NPCs' });
+    }
+
+    const npc = await Npc.findByPk(req.params.id);
+    if (!npc) {
+      return res.status(404).json({ success: false, message: 'NPC not found' });
+    }
+
+    await npc.destroy();
+    res.json({ success: true, data: null, message: 'NPC deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const addNpcNote = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const npc = await Npc.findByPk(req.params.id);
+    if (!npc) {
+      return res.status(404).json({ success: false, message: 'NPC not found' });
+    }
+
+    const { content, visibilityLevel = 'Private' } = req.body;
+    if (!content) {
+      return res.status(400).json({ success: false, message: 'content is required' });
+    }
+
+    if (!context?.bypassVisibility) {
+      if (visibilityLevel === 'DM') {
+        return res.status(403).json({ success: false, message: 'Players cannot create DM-only notes' });
+      }
+      if (visibilityLevel === 'Party' && !context?.campaignId) {
+        return res.status(400).json({ success: false, message: 'Party notes require an active campaign' });
+      }
+    }
+
+    const note = await NpcNote.create({
+      npc_id: npc.id,
+      author_id: req.user.id,
+      content,
+      visibility_level: visibilityLevel,
+      created_at: new Date(),
+      updated_at: new Date()
+    });
+
+    const hydrated = await NpcNote.findByPk(note.id, { include: [{ model: User, as: 'author', attributes: ['id', 'username'] }] });
+    const plain = hydrated.get({ plain: true });
+    if (!context?.bypassVisibility) {
+      const filtered = filterNotesForContext([plain], context);
+      if (!filtered.length) {
+        return res.status(403).json({ success: false, message: 'Note visibility does not match current context' });
+      }
+    }
+
+    res.status(201).json({ success: true, data: plain, message: 'Note created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateNpcNote = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const note = await NpcNote.findByPk(req.params.noteId);
+    if (!note) {
+      return res.status(404).json({ success: false, message: 'NPC note not found' });
+    }
+
+    if (!context?.bypassVisibility && note.author_id !== req.user.id) {
+      return res.status(403).json({ success: false, message: 'You can only update your own notes' });
+    }
+
+    const { content, visibilityLevel } = req.body;
+    if (typeof content !== 'undefined') note.content = content;
+    if (typeof visibilityLevel !== 'undefined') {
+      if (!context?.bypassVisibility && visibilityLevel === 'DM') {
+        return res.status(403).json({ success: false, message: 'Players cannot create DM-only notes' });
+      }
+      if (!context?.bypassVisibility && visibilityLevel === 'Party' && !context?.campaignId) {
+        return res.status(400).json({ success: false, message: 'Party notes require an active campaign' });
+      }
+      note.visibility_level = visibilityLevel;
+    }
+    note.updated_at = new Date();
+
+    await note.save();
+    const hydrated = await NpcNote.findByPk(note.id, { include: [{ model: User, as: 'author', attributes: ['id', 'username'] }] });
+    const plain = hydrated.get({ plain: true });
+    if (!context?.bypassVisibility) {
+      const filtered = filterNotesForContext([plain], context);
+      if (!filtered.length) {
+        return res.status(403).json({ success: false, message: 'Note visibility does not match current context' });
+      }
+    }
+
+    res.json({ success: true, data: plain, message: 'Note updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteNpcNote = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const note = await NpcNote.findByPk(req.params.noteId);
+    if (!note) {
+      return res.status(404).json({ success: false, message: 'NPC note not found' });
+    }
+
+    if (!context?.bypassVisibility && note.author_id !== req.user.id) {
+      return res.status(403).json({ success: false, message: 'You can only delete your own notes' });
+    }
+
+    await note.destroy();
+    res.json({ success: true, data: null, message: 'Note deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const listNpcTypes = async (_req, res) => {
+  try {
+    const types = await NpcType.findAll({ order: [['name', 'ASC']] });
+    res.json({ success: true, data: types });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createNpcType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage NPC types' });
+    }
+
+    const { name, description } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    const type = await NpcType.create({ name, description, created_at: new Date() });
+    res.status(201).json({ success: true, data: type, message: 'NPC type created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateNpcType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage NPC types' });
+    }
+
+    const type = await NpcType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'NPC type not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name !== 'undefined') type.name = name;
+    if (typeof description !== 'undefined') type.description = description;
+    await type.save();
+
+    res.json({ success: true, data: type, message: 'NPC type updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteNpcType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage NPC types' });
+    }
+
+    const type = await NpcType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'NPC type not found' });
+    }
+
+    await type.destroy();
+    res.json({ success: true, data: null, message: 'NPC type deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/controllers/organisationController.js
+++ b/backend/src/controllers/organisationController.js
@@ -1,0 +1,269 @@
+import {
+  Organisation,
+  OrganisationType,
+  OrganisationVisibility,
+  OrganisationLocation,
+  OrganisationRelationship,
+  Location,
+  Campaign,
+  User
+} from '../models/index.js';
+import {
+  applyWorldScope,
+  buildVisibilityInclude,
+  normalizeVisibilityEntries,
+  resolveDefaultVisibility,
+  syncVisibilityEntries
+} from '../utils/visibility.js';
+
+const organisationIncludes = (context) => ([
+  { model: OrganisationType, as: 'type' },
+  {
+    model: Location,
+    as: 'locations',
+    through: { attributes: [] }
+  },
+  {
+    model: OrganisationRelationship,
+    as: 'relationships',
+    include: [
+      { model: Organisation, as: 'relatedOrganisation', attributes: ['id', 'name'] }
+    ]
+  },
+  buildVisibilityInclude({
+    context,
+    model: OrganisationVisibility,
+    as: 'visibility',
+    include: [
+      { model: Campaign, as: 'campaign', attributes: ['id', 'name'] },
+      { model: User, as: 'player', attributes: ['id', 'username'] }
+    ]
+  })
+]);
+
+const ensurePrivileged = (context) => context?.isWorldAdmin || context?.isDm;
+
+const loadOrganisation = async (id, context) => Organisation.findByPk(id, {
+  include: organisationIncludes(context)
+});
+
+export const listOrganisations = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (context?.restrictAll && !context?.bypassVisibility) {
+      return res.json({ success: true, data: [] });
+    }
+
+    const where = applyWorldScope({}, context);
+    const organisations = await Organisation.findAll({
+      where,
+      include: organisationIncludes(context),
+      order: [['name', 'ASC']],
+      distinct: true
+    });
+
+    res.json({ success: true, data: organisations });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const getOrganisation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    const organisation = await loadOrganisation(req.params.id, context);
+    if (!organisation) {
+      return res.status(404).json({ success: false, message: 'Organisation not found' });
+    }
+
+    if (!context?.bypassVisibility) {
+      const visible = organisation.visibility?.some((entry) => {
+        if (entry.campaign_id && context?.campaignId && entry.campaign_id === context.campaignId) return true;
+        if (entry.player_id && entry.player_id === context?.playerId) return true;
+        return entry.campaign_id === null && entry.player_id === null;
+      });
+      if (!visible) {
+        return res.status(403).json({ success: false, message: 'Organisation is not visible in this context' });
+      }
+    }
+
+    res.json({ success: true, data: organisation });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createOrganisation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to create organisations' });
+    }
+
+    const { name, description, motto, worldId, typeId, visibility, locationIds = [] } = req.body;
+    const effectiveWorldId = worldId || context?.worldId || context?.worldScope?.[0];
+
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+    if (!effectiveWorldId) {
+      return res.status(400).json({ success: false, message: 'worldId is required for organisations' });
+    }
+
+    const organisation = await Organisation.create({
+      name,
+      description,
+      motto,
+      world_id: effectiveWorldId,
+      type_id: typeId || null,
+      created_by: req.user.id,
+      created_at: new Date(),
+      updated_at: new Date()
+    });
+
+    if (locationIds.length) {
+      const assignments = locationIds.map((locationId) => ({ organisation_id: organisation.id, location_id: locationId }));
+      await OrganisationLocation.bulkCreate(assignments, { ignoreDuplicates: true });
+    }
+
+    const visibilityEntries = normalizeVisibilityEntries(visibility?.length ? visibility : resolveDefaultVisibility(context));
+    if (visibilityEntries.length) {
+      await syncVisibilityEntries(OrganisationVisibility, 'organisation_id', organisation.id, visibilityEntries);
+    }
+
+    const hydrated = await loadOrganisation(organisation.id, context);
+    res.status(201).json({ success: true, data: hydrated, message: 'Organisation created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateOrganisation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to update organisations' });
+    }
+
+    const organisation = await Organisation.findByPk(req.params.id);
+    if (!organisation) {
+      return res.status(404).json({ success: false, message: 'Organisation not found' });
+    }
+
+    const { name, description, motto, worldId, typeId, visibility, locationIds } = req.body;
+
+    if (typeof name !== 'undefined') organisation.name = name;
+    if (typeof description !== 'undefined') organisation.description = description;
+    if (typeof motto !== 'undefined') organisation.motto = motto;
+    if (typeof worldId !== 'undefined') organisation.world_id = worldId || organisation.world_id;
+    if (typeof typeId !== 'undefined') organisation.type_id = typeId || null;
+    organisation.updated_at = new Date();
+
+    await organisation.save();
+
+    if (Array.isArray(locationIds)) {
+      await OrganisationLocation.destroy({ where: { organisation_id: organisation.id } });
+      if (locationIds.length) {
+        await OrganisationLocation.bulkCreate(locationIds.map((locationId) => ({ organisation_id: organisation.id, location_id: locationId })), { ignoreDuplicates: true });
+      }
+    }
+
+    if (visibility) {
+      await syncVisibilityEntries(OrganisationVisibility, 'organisation_id', organisation.id, visibility);
+    }
+
+    const hydrated = await loadOrganisation(organisation.id, context);
+    res.json({ success: true, data: hydrated, message: 'Organisation updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteOrganisation = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!ensurePrivileged(context)) {
+      return res.status(403).json({ success: false, message: 'Insufficient permissions to delete organisations' });
+    }
+
+    const organisation = await Organisation.findByPk(req.params.id);
+    if (!organisation) {
+      return res.status(404).json({ success: false, message: 'Organisation not found' });
+    }
+
+    await organisation.destroy();
+    res.json({ success: true, data: null, message: 'Organisation deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const listOrganisationTypes = async (_req, res) => {
+  try {
+    const types = await OrganisationType.findAll({ order: [['name', 'ASC']] });
+    res.json({ success: true, data: types });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createOrganisationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage organisation types' });
+    }
+
+    const { name, description } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    const type = await OrganisationType.create({ name, description, created_at: new Date() });
+    res.status(201).json({ success: true, data: type, message: 'Organisation type created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateOrganisationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage organisation types' });
+    }
+
+    const type = await OrganisationType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'Organisation type not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name !== 'undefined') type.name = name;
+    if (typeof description !== 'undefined') type.description = description;
+    await type.save();
+
+    res.json({ success: true, data: type, message: 'Organisation type updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteOrganisationType = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may manage organisation types' });
+    }
+
+    const type = await OrganisationType.findByPk(req.params.id);
+    if (!type) {
+      return res.status(404).json({ success: false, message: 'Organisation type not found' });
+    }
+
+    await type.destroy();
+    res.json({ success: true, data: null, message: 'Organisation type deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/controllers/raceController.js
+++ b/backend/src/controllers/raceController.js
@@ -1,0 +1,71 @@
+import Race from '../models/Race.js';
+
+export const listRaces = async (_req, res) => {
+  try {
+    const races = await Race.findAll({ order: [['name', 'ASC']] });
+    res.json({ success: true, data: races });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const createRace = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may create races' });
+    }
+
+    const { name, description } = req.body;
+    if (!name) {
+      return res.status(400).json({ success: false, message: 'name is required' });
+    }
+
+    const race = await Race.create({ name, description, created_by: req.user.id, created_at: new Date() });
+    res.status(201).json({ success: true, data: race, message: 'Race created' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const updateRace = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may update races' });
+    }
+
+    const race = await Race.findByPk(req.params.id);
+    if (!race) {
+      return res.status(404).json({ success: false, message: 'Race not found' });
+    }
+
+    const { name, description } = req.body;
+    if (typeof name !== 'undefined') race.name = name;
+    if (typeof description !== 'undefined') race.description = description;
+
+    await race.save();
+    res.json({ success: true, data: race, message: 'Race updated' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const deleteRace = async (req, res) => {
+  try {
+    const context = req.visibilityContext;
+    if (!context?.isWorldAdmin) {
+      return res.status(403).json({ success: false, message: 'Only world admins may delete races' });
+    }
+
+    const race = await Race.findByPk(req.params.id);
+    if (!race) {
+      return res.status(404).json({ success: false, message: 'Race not found' });
+    }
+
+    await race.destroy();
+    res.json({ success: true, data: null, message: 'Race deleted' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,4 +1,4 @@
-import { User } from '../models/index.js';
+import { User, SystemRole } from '../models/index.js';
 import { verifyToken } from '../utils/token.js';
 
 export const authenticateToken = async (req, res, next) => {
@@ -12,7 +12,8 @@ export const authenticateToken = async (req, res, next) => {
   try {
     const payload = verifyToken(token);
     const user = await User.findByPk(payload.sub, {
-      attributes: ['id', 'username', 'email', 'active']
+      attributes: ['id', 'username', 'email', 'active'],
+      include: [{ model: SystemRole, as: 'systemRoles', through: { attributes: [] }, attributes: ['id', 'name'] }]
     });
 
     if (!user || !user.active) {

--- a/backend/src/middleware/contextMiddleware.js
+++ b/backend/src/middleware/contextMiddleware.js
@@ -1,0 +1,19 @@
+const normalizeId = (value) => {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length ? trimmed : null;
+};
+
+export const attachContext = (req, _res, next) => {
+  const headers = req.headers || {};
+  const campaignId = normalizeId(headers['x-active-campaign'] || headers['x-campaign-id'] || headers['x-campaign'] || req.query?.campaignId || req.body?.campaignId);
+  const characterId = normalizeId(headers['x-active-character'] || headers['x-character-id'] || req.query?.characterId || req.body?.characterId);
+  const worldId = normalizeId(headers['x-active-world'] || headers['x-world-id'] || req.query?.worldId || req.body?.worldId);
+
+  req.activeContext = {
+    campaignId,
+    characterId,
+    worldId
+  };
+  next();
+};

--- a/backend/src/middleware/visibilityMiddleware.js
+++ b/backend/src/middleware/visibilityMiddleware.js
@@ -1,0 +1,88 @@
+import { Op } from 'sequelize';
+import {
+  Campaign,
+  CampaignRole,
+  UserCampaignRole
+} from '../models/index.js';
+
+const DM_ROLE_NAMES = ['DM', 'Dungeon Master'];
+const WORLD_ADMIN_ROLE_NAMES = ['WorldAdmin', 'World Admin'];
+
+const unique = (values) => [...new Set(values.filter(Boolean))];
+
+export const applyVisibilityFilter = (options = {}) => async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: 'Authentication required' });
+    }
+
+    const roleNames = (req.user.systemRoles || []).map((role) => role.name);
+    const isWorldAdmin = roleNames.some((name) => WORLD_ADMIN_ROLE_NAMES.includes(name));
+    const isDm = roleNames.some((name) => DM_ROLE_NAMES.includes(name));
+
+    const context = req.activeContext || {};
+    let { campaignId = null, worldId = null, characterId = null } = context;
+
+    if (campaignId && !worldId) {
+      const campaign = await Campaign.findByPk(campaignId, { attributes: ['id', 'world_id'] });
+      worldId = campaign?.world_id || null;
+    }
+
+    let managedCampaignIds = [];
+    let managedWorldIds = [];
+
+    if (isDm) {
+      const dmAssignments = await UserCampaignRole.findAll({
+        where: { user_id: req.user.id },
+        include: [
+          {
+            model: CampaignRole,
+            as: 'role',
+            where: { name: { [Op.in]: DM_ROLE_NAMES } },
+            attributes: ['id', 'name']
+          },
+          {
+            model: Campaign,
+            as: 'campaign',
+            attributes: ['id', 'world_id']
+          }
+        ]
+      });
+
+      managedCampaignIds = unique(dmAssignments.map((assignment) => assignment.campaign?.id || assignment.campaign_id));
+      managedWorldIds = unique(dmAssignments.map((assignment) => assignment.campaign?.world_id));
+    }
+
+    const visibilityContext = {
+      roleNames,
+      isWorldAdmin,
+      isDm,
+      bypassVisibility: isWorldAdmin || (isDm && options.dmBypass !== false),
+      campaignId,
+      characterId,
+      worldId,
+      playerId: req.user.id,
+      managedCampaignIds,
+      managedWorldIds,
+      worldScope: isWorldAdmin ? null : unique([worldId, ...managedWorldIds].filter(Boolean))
+    };
+
+    if (!visibilityContext.bypassVisibility && !visibilityContext.campaignId && !visibilityContext.worldId && !visibilityContext.managedWorldIds.length) {
+      visibilityContext.restrictAll = true;
+      if (req.method === 'GET' && options.blockWithoutContext) {
+        return res.json({ success: true, data: [] });
+      }
+    }
+
+    if (options.requireVisibilityForWrite && req.method !== 'GET' && !visibilityContext.bypassVisibility) {
+      if (!visibilityContext.campaignId && !visibilityContext.playerId) {
+        return res.status(403).json({ success: false, message: 'Active campaign context is required for this action' });
+      }
+    }
+
+    req.visibilityContext = visibilityContext;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/migrations/0002_world_entities.js
+++ b/backend/src/migrations/0002_world_entities.js
@@ -1,0 +1,216 @@
+/* eslint-disable camelcase */
+
+const DM_ROLE_NAMES = ['DM', 'Dungeon Master'];
+const WORLD_ADMIN_ROLE_NAMES = ['WorldAdmin', 'World Admin'];
+const PLAYER_ROLE_NAMES = ['Player'];
+
+exports.up = (pgm) => {
+  // --- utility ---
+  pgm.createExtension('pgcrypto', { ifNotExists: true });
+
+  // --- races ---
+  pgm.createTable('races', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(100)', notNull: true, unique: true },
+    description: { type: 'text' },
+    created_by: { type: 'uuid', references: '"users"', onDelete: 'set null' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+
+  // --- location taxonomy ---
+  pgm.createTable('location_types', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(100)', notNull: true, unique: true },
+    description: { type: 'text' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+
+  pgm.createTable('locations', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(150)', notNull: true },
+    description: { type: 'text' },
+    summary: { type: 'varchar(255)' },
+    world_id: { type: 'uuid', references: '"worlds"', notNull: true, onDelete: 'cascade' },
+    type_id: { type: 'uuid', references: '"location_types"', onDelete: 'set null' },
+    created_by: { type: 'uuid', references: '"users"', onDelete: 'set null' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.createIndex('locations', ['world_id']);
+  pgm.createIndex('locations', ['type_id']);
+
+  pgm.createTable('location_visibility', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    location_id: { type: 'uuid', notNull: true, references: '"locations"', onDelete: 'cascade' },
+    campaign_id: { type: 'uuid', references: '"campaigns"', onDelete: 'cascade' },
+    player_id: { type: 'uuid', references: '"users"', onDelete: 'cascade' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('location_visibility', 'location_visibility_unique_scope', {
+    unique: ['location_id', 'campaign_id', 'player_id']
+  });
+
+  // --- organisations ---
+  pgm.createTable('organisation_types', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(120)', notNull: true, unique: true },
+    description: { type: 'text' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+
+  pgm.createTable('organisations', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(150)', notNull: true },
+    description: { type: 'text' },
+    motto: { type: 'varchar(255)' },
+    world_id: { type: 'uuid', references: '"worlds"', notNull: true, onDelete: 'cascade' },
+    type_id: { type: 'uuid', references: '"organisation_types"', onDelete: 'set null' },
+    created_by: { type: 'uuid', references: '"users"', onDelete: 'set null' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.createIndex('organisations', ['world_id']);
+  pgm.createIndex('organisations', ['type_id']);
+
+  pgm.createTable('organisation_visibility', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    organisation_id: { type: 'uuid', notNull: true, references: '"organisations"', onDelete: 'cascade' },
+    campaign_id: { type: 'uuid', references: '"campaigns"', onDelete: 'cascade' },
+    player_id: { type: 'uuid', references: '"users"', onDelete: 'cascade' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('organisation_visibility', 'organisation_visibility_unique_scope', {
+    unique: ['organisation_id', 'campaign_id', 'player_id']
+  });
+
+  pgm.createTable('organisation_locations', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    organisation_id: { type: 'uuid', notNull: true, references: '"organisations"', onDelete: 'cascade' },
+    location_id: { type: 'uuid', notNull: true, references: '"locations"', onDelete: 'cascade' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('organisation_locations', 'organisation_locations_unique_pair', {
+    unique: ['organisation_id', 'location_id']
+  });
+
+  pgm.createTable('organisation_relationships', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    organisation_id: { type: 'uuid', notNull: true, references: '"organisations"', onDelete: 'cascade' },
+    related_organisation_id: { type: 'uuid', notNull: true, references: '"organisations"', onDelete: 'cascade' },
+    relationship_type: { type: 'varchar(100)' },
+    description: { type: 'text' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('organisation_relationships', 'organisation_relationships_not_reflexive', {
+    check: 'organisation_id <> related_organisation_id'
+  });
+  pgm.sql(`
+    CREATE UNIQUE INDEX organisation_relationship_pair_idx
+    ON organisation_relationships (
+      LEAST(organisation_id::text, related_organisation_id::text),
+      GREATEST(organisation_id::text, related_organisation_id::text),
+      COALESCE(relationship_type, '')
+    );
+  `);
+
+  // --- NPCs ---
+  pgm.createTable('npc_types', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(120)', notNull: true, unique: true },
+    description: { type: 'text' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+
+  pgm.createTable('npcs', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    name: { type: 'varchar(150)', notNull: true },
+    description: { type: 'text' },
+    demeanor: { type: 'varchar(255)' },
+    world_id: { type: 'uuid', references: '"worlds"', notNull: true, onDelete: 'cascade' },
+    race_id: { type: 'uuid', references: '"races"', onDelete: 'set null' },
+    type_id: { type: 'uuid', references: '"npc_types"', onDelete: 'set null' },
+    created_by: { type: 'uuid', references: '"users"', onDelete: 'set null' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.createIndex('npcs', ['world_id']);
+  pgm.createIndex('npcs', ['race_id']);
+  pgm.createIndex('npcs', ['type_id']);
+
+  pgm.createTable('npc_visibility', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    npc_id: { type: 'uuid', notNull: true, references: '"npcs"', onDelete: 'cascade' },
+    campaign_id: { type: 'uuid', references: '"campaigns"', onDelete: 'cascade' },
+    player_id: { type: 'uuid', references: '"users"', onDelete: 'cascade' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('npc_visibility', 'npc_visibility_unique_scope', {
+    unique: ['npc_id', 'campaign_id', 'player_id']
+  });
+
+  pgm.createType('npc_note_visibility_level', ['Private', 'Party', 'DM']);
+  pgm.createTable('npc_notes', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    npc_id: { type: 'uuid', notNull: true, references: '"npcs"', onDelete: 'cascade' },
+    author_id: { type: 'uuid', references: '"users"', onDelete: 'set null' },
+    content: { type: 'text', notNull: true },
+    visibility_level: { type: 'npc_note_visibility_level', notNull: true, default: 'Private' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+
+  pgm.createTable('npc_relationships', {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    npc_id: { type: 'uuid', notNull: true, references: '"npcs"', onDelete: 'cascade' },
+    related_npc_id: { type: 'uuid', notNull: true, references: '"npcs"', onDelete: 'cascade' },
+    relationship_type: { type: 'varchar(100)' },
+    description: { type: 'text' },
+    created_at: { type: 'timestamp', default: pgm.func('current_timestamp') }
+  });
+  pgm.addConstraint('npc_relationships', 'npc_relationships_not_reflexive', {
+    check: 'npc_id <> related_npc_id'
+  });
+  pgm.sql(`
+    CREATE UNIQUE INDEX npc_relationship_pair_idx
+    ON npc_relationships (
+      LEAST(npc_id::text, related_npc_id::text),
+      GREATEST(npc_id::text, related_npc_id::text),
+      COALESCE(relationship_type, '')
+    );
+  `);
+
+  // --- seed system roles aligned with platform roles ---
+  const insertRole = (name, description) => `
+    INSERT INTO system_roles (id, name, description)
+    VALUES (gen_random_uuid(), '${name.replace(/'/g, "''")}', '${description.replace(/'/g, "''")}')
+    ON CONFLICT (name) DO NOTHING;
+  `;
+
+  [...WORLD_ADMIN_ROLE_NAMES, ...DM_ROLE_NAMES, ...PLAYER_ROLE_NAMES].forEach((roleName) => {
+    let description = '';
+    if (WORLD_ADMIN_ROLE_NAMES.includes(roleName)) description = 'World-level administration rights.';
+    else if (DM_ROLE_NAMES.includes(roleName)) description = 'Dungeon Master access for assigned campaigns.';
+    else description = 'Player access scoped by character context.';
+    pgm.sql(insertRole(roleName, description));
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.sql('DROP INDEX IF EXISTS npc_relationship_pair_idx');
+  pgm.sql('DROP INDEX IF EXISTS organisation_relationship_pair_idx');
+  pgm.dropTable('npc_relationships');
+  pgm.dropTable('npc_notes');
+  pgm.dropType('npc_note_visibility_level');
+  pgm.dropTable('npc_visibility');
+  pgm.dropTable('npcs');
+  pgm.dropTable('npc_types');
+  pgm.dropTable('organisation_relationships');
+  pgm.dropTable('organisation_locations');
+  pgm.dropTable('organisation_visibility');
+  pgm.dropTable('organisations');
+  pgm.dropTable('organisation_types');
+  pgm.dropTable('location_visibility');
+  pgm.dropTable('locations');
+  pgm.dropTable('location_types');
+  pgm.dropTable('races');
+};

--- a/backend/src/models/Location.js
+++ b/backend/src/models/Location.js
@@ -1,0 +1,21 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class Location extends Model {}
+
+Location.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  summary: DataTypes.STRING,
+  world_id: { type: DataTypes.UUID, allowNull: false },
+  type_id: DataTypes.UUID,
+  created_by: DataTypes.UUID,
+  created_at: DataTypes.DATE,
+  updated_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'Location',
+  tableName: 'locations',
+  timestamps: false
+});

--- a/backend/src/models/LocationType.js
+++ b/backend/src/models/LocationType.js
@@ -1,0 +1,16 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class LocationType extends Model {}
+
+LocationType.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'LocationType',
+  tableName: 'location_types',
+  timestamps: false
+});

--- a/backend/src/models/LocationVisibility.js
+++ b/backend/src/models/LocationVisibility.js
@@ -1,0 +1,17 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class LocationVisibility extends Model {}
+
+LocationVisibility.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  location_id: { type: DataTypes.UUID, allowNull: false },
+  campaign_id: DataTypes.UUID,
+  player_id: DataTypes.UUID,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'LocationVisibility',
+  tableName: 'location_visibility',
+  timestamps: false
+});

--- a/backend/src/models/Npc.js
+++ b/backend/src/models/Npc.js
@@ -1,0 +1,22 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class Npc extends Model {}
+
+Npc.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  demeanor: DataTypes.STRING,
+  world_id: { type: DataTypes.UUID, allowNull: false },
+  race_id: DataTypes.UUID,
+  type_id: DataTypes.UUID,
+  created_by: DataTypes.UUID,
+  created_at: DataTypes.DATE,
+  updated_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'Npc',
+  tableName: 'npcs',
+  timestamps: false
+});

--- a/backend/src/models/NpcNote.js
+++ b/backend/src/models/NpcNote.js
@@ -1,0 +1,19 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class NpcNote extends Model {}
+
+NpcNote.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  npc_id: { type: DataTypes.UUID, allowNull: false },
+  author_id: DataTypes.UUID,
+  content: { type: DataTypes.TEXT, allowNull: false },
+  visibility_level: { type: DataTypes.ENUM('Private', 'Party', 'DM'), allowNull: false, defaultValue: 'Private' },
+  created_at: DataTypes.DATE,
+  updated_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'NpcNote',
+  tableName: 'npc_notes',
+  timestamps: false
+});

--- a/backend/src/models/NpcRelationship.js
+++ b/backend/src/models/NpcRelationship.js
@@ -1,0 +1,18 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class NpcRelationship extends Model {}
+
+NpcRelationship.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  npc_id: { type: DataTypes.UUID, allowNull: false },
+  related_npc_id: { type: DataTypes.UUID, allowNull: false },
+  relationship_type: DataTypes.STRING,
+  description: DataTypes.TEXT,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'NpcRelationship',
+  tableName: 'npc_relationships',
+  timestamps: false
+});

--- a/backend/src/models/NpcType.js
+++ b/backend/src/models/NpcType.js
@@ -1,0 +1,16 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class NpcType extends Model {}
+
+NpcType.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'NpcType',
+  tableName: 'npc_types',
+  timestamps: false
+});

--- a/backend/src/models/NpcVisibility.js
+++ b/backend/src/models/NpcVisibility.js
@@ -1,0 +1,17 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class NpcVisibility extends Model {}
+
+NpcVisibility.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  npc_id: { type: DataTypes.UUID, allowNull: false },
+  campaign_id: DataTypes.UUID,
+  player_id: DataTypes.UUID,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'NpcVisibility',
+  tableName: 'npc_visibility',
+  timestamps: false
+});

--- a/backend/src/models/Organisation.js
+++ b/backend/src/models/Organisation.js
@@ -1,0 +1,21 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class Organisation extends Model {}
+
+Organisation.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  motto: DataTypes.STRING,
+  world_id: { type: DataTypes.UUID, allowNull: false },
+  type_id: DataTypes.UUID,
+  created_by: DataTypes.UUID,
+  created_at: DataTypes.DATE,
+  updated_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'Organisation',
+  tableName: 'organisations',
+  timestamps: false
+});

--- a/backend/src/models/OrganisationLocation.js
+++ b/backend/src/models/OrganisationLocation.js
@@ -1,0 +1,16 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class OrganisationLocation extends Model {}
+
+OrganisationLocation.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  organisation_id: { type: DataTypes.UUID, allowNull: false },
+  location_id: { type: DataTypes.UUID, allowNull: false },
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'OrganisationLocation',
+  tableName: 'organisation_locations',
+  timestamps: false
+});

--- a/backend/src/models/OrganisationRelationship.js
+++ b/backend/src/models/OrganisationRelationship.js
@@ -1,0 +1,18 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class OrganisationRelationship extends Model {}
+
+OrganisationRelationship.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  organisation_id: { type: DataTypes.UUID, allowNull: false },
+  related_organisation_id: { type: DataTypes.UUID, allowNull: false },
+  relationship_type: DataTypes.STRING,
+  description: DataTypes.TEXT,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'OrganisationRelationship',
+  tableName: 'organisation_relationships',
+  timestamps: false
+});

--- a/backend/src/models/OrganisationType.js
+++ b/backend/src/models/OrganisationType.js
@@ -1,0 +1,16 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class OrganisationType extends Model {}
+
+OrganisationType.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'OrganisationType',
+  tableName: 'organisation_types',
+  timestamps: false
+});

--- a/backend/src/models/OrganisationVisibility.js
+++ b/backend/src/models/OrganisationVisibility.js
@@ -1,0 +1,17 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class OrganisationVisibility extends Model {}
+
+OrganisationVisibility.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  organisation_id: { type: DataTypes.UUID, allowNull: false },
+  campaign_id: DataTypes.UUID,
+  player_id: DataTypes.UUID,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'OrganisationVisibility',
+  tableName: 'organisation_visibility',
+  timestamps: false
+});

--- a/backend/src/models/Race.js
+++ b/backend/src/models/Race.js
@@ -1,0 +1,17 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../config/db.js';
+
+export default class Race extends Model {}
+
+Race.init({
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  created_by: DataTypes.UUID,
+  created_at: DataTypes.DATE
+}, {
+  sequelize,
+  modelName: 'Race',
+  tableName: 'races',
+  timestamps: false
+});

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -8,6 +8,20 @@ import CampaignRole from './CampaignRole.js';
 import UserCampaignRole from './UserCampaignRole.js';
 import Character from './Character.js';
 import CharacterCampaign from './CharacterCampaign.js';
+import Race from './Race.js';
+import LocationType from './LocationType.js';
+import Location from './Location.js';
+import LocationVisibility from './LocationVisibility.js';
+import OrganisationType from './OrganisationType.js';
+import Organisation from './Organisation.js';
+import OrganisationVisibility from './OrganisationVisibility.js';
+import OrganisationLocation from './OrganisationLocation.js';
+import OrganisationRelationship from './OrganisationRelationship.js';
+import NpcType from './NpcType.js';
+import Npc from './Npc.js';
+import NpcVisibility from './NpcVisibility.js';
+import NpcNote from './NpcNote.js';
+import NpcRelationship from './NpcRelationship.js';
 
 User.hasMany(Character, { as: 'characters', foreignKey: 'user_id' });
 Character.belongsTo(User, { as: 'owner', foreignKey: 'user_id' });
@@ -86,6 +100,55 @@ CharacterCampaign.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id
 Character.hasMany(CharacterCampaign, { as: 'characterCampaigns', foreignKey: 'character_id' });
 Campaign.hasMany(CharacterCampaign, { as: 'characterCampaigns', foreignKey: 'campaign_id' });
 
+World.hasMany(Location, { as: 'locations', foreignKey: 'world_id' });
+Location.belongsTo(World, { as: 'world', foreignKey: 'world_id' });
+Location.belongsTo(LocationType, { as: 'type', foreignKey: 'type_id' });
+Location.belongsTo(User, { as: 'creator', foreignKey: 'created_by' });
+Location.hasMany(LocationVisibility, { as: 'visibility', foreignKey: 'location_id' });
+LocationVisibility.belongsTo(Location, { as: 'location', foreignKey: 'location_id' });
+LocationVisibility.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+LocationVisibility.belongsTo(User, { as: 'player', foreignKey: 'player_id' });
+
+World.hasMany(Organisation, { as: 'organisations', foreignKey: 'world_id' });
+Organisation.belongsTo(World, { as: 'world', foreignKey: 'world_id' });
+Organisation.belongsTo(OrganisationType, { as: 'type', foreignKey: 'type_id' });
+Organisation.belongsTo(User, { as: 'creator', foreignKey: 'created_by' });
+Organisation.hasMany(OrganisationVisibility, { as: 'visibility', foreignKey: 'organisation_id' });
+OrganisationVisibility.belongsTo(Organisation, { as: 'organisation', foreignKey: 'organisation_id' });
+OrganisationVisibility.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+OrganisationVisibility.belongsTo(User, { as: 'player', foreignKey: 'player_id' });
+Organisation.belongsToMany(Location, {
+  through: OrganisationLocation,
+  as: 'locations',
+  foreignKey: 'organisation_id',
+  otherKey: 'location_id'
+});
+Location.belongsToMany(Organisation, {
+  through: OrganisationLocation,
+  as: 'organisations',
+  foreignKey: 'location_id',
+  otherKey: 'organisation_id'
+});
+OrganisationRelationship.belongsTo(Organisation, { as: 'organisation', foreignKey: 'organisation_id' });
+OrganisationRelationship.belongsTo(Organisation, { as: 'relatedOrganisation', foreignKey: 'related_organisation_id' });
+Organisation.hasMany(OrganisationRelationship, { as: 'relationships', foreignKey: 'organisation_id' });
+
+Race.hasMany(Npc, { as: 'npcs', foreignKey: 'race_id' });
+Npc.belongsTo(Race, { as: 'race', foreignKey: 'race_id' });
+Npc.belongsTo(World, { as: 'world', foreignKey: 'world_id' });
+Npc.belongsTo(NpcType, { as: 'type', foreignKey: 'type_id' });
+Npc.belongsTo(User, { as: 'creator', foreignKey: 'created_by' });
+Npc.hasMany(NpcVisibility, { as: 'visibility', foreignKey: 'npc_id' });
+NpcVisibility.belongsTo(Npc, { as: 'npc', foreignKey: 'npc_id' });
+NpcVisibility.belongsTo(Campaign, { as: 'campaign', foreignKey: 'campaign_id' });
+NpcVisibility.belongsTo(User, { as: 'player', foreignKey: 'player_id' });
+Npc.hasMany(NpcNote, { as: 'notes', foreignKey: 'npc_id' });
+NpcNote.belongsTo(Npc, { as: 'npc', foreignKey: 'npc_id' });
+NpcNote.belongsTo(User, { as: 'author', foreignKey: 'author_id' });
+Npc.hasMany(NpcRelationship, { as: 'relationships', foreignKey: 'npc_id' });
+NpcRelationship.belongsTo(Npc, { as: 'npc', foreignKey: 'npc_id' });
+NpcRelationship.belongsTo(Npc, { as: 'relatedNpc', foreignKey: 'related_npc_id' });
+
 export {
   sequelize,
   User,
@@ -96,5 +159,19 @@ export {
   CampaignRole,
   UserCampaignRole,
   Character,
-  CharacterCampaign
+  CharacterCampaign,
+  Race,
+  LocationType,
+  Location,
+  LocationVisibility,
+  OrganisationType,
+  Organisation,
+  OrganisationVisibility,
+  OrganisationLocation,
+  OrganisationRelationship,
+  NpcType,
+  Npc,
+  NpcVisibility,
+  NpcNote,
+  NpcRelationship
 };

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -7,8 +7,15 @@ import campaignRoleRoutes from './campaignRoleRoutes.js';
 import userCampaignRoleRoutes from './userCampaignRoleRoutes.js';
 import characterRoutes from './characterRoutes.js';
 import characterCampaignRoutes from './characterCampaignRoutes.js';
+import locationRoutes from './locationRoutes.js';
+import organisationRoutes from './organisationRoutes.js';
+import npcRoutes from './npcRoutes.js';
+import raceRoutes from './raceRoutes.js';
+import { attachContext } from '../middleware/contextMiddleware.js';
 
 const router = Router();
+
+router.use(attachContext);
 
 router.use('/users', userRoutes);
 router.use('/system-roles', systemRoleRoutes);
@@ -18,5 +25,9 @@ router.use('/campaign-roles', campaignRoleRoutes);
 router.use('/user-campaign-roles', userCampaignRoleRoutes);
 router.use('/characters', characterRoutes);
 router.use('/character-campaigns', characterCampaignRoutes);
+router.use('/locations', locationRoutes);
+router.use('/organisations', organisationRoutes);
+router.use('/npcs', npcRoutes);
+router.use('/races', raceRoutes);
 
 export default router;

--- a/backend/src/routes/locationRoutes.js
+++ b/backend/src/routes/locationRoutes.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listLocations,
+  getLocation,
+  createLocation,
+  updateLocation,
+  deleteLocation,
+  listLocationTypes,
+  createLocationType,
+  updateLocationType,
+  deleteLocationType
+} from '../controllers/locationController.js';
+import { applyVisibilityFilter } from '../middleware/visibilityMiddleware.js';
+
+const router = Router();
+
+router.use(applyVisibilityFilter({ requireVisibilityForWrite: true }));
+
+router.get('/', listLocations);
+router.get('/types', listLocationTypes);
+router.post('/types', createLocationType);
+router.put('/types/:id', updateLocationType);
+router.delete('/types/:id', deleteLocationType);
+router.get('/:id', getLocation);
+router.post('/', createLocation);
+router.put('/:id', updateLocation);
+router.delete('/:id', deleteLocation);
+
+export default router;

--- a/backend/src/routes/npcRoutes.js
+++ b/backend/src/routes/npcRoutes.js
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import {
+  listNpcs,
+  getNpc,
+  createNpc,
+  updateNpc,
+  deleteNpc,
+  addNpcNote,
+  updateNpcNote,
+  deleteNpcNote,
+  listNpcTypes,
+  createNpcType,
+  updateNpcType,
+  deleteNpcType
+} from '../controllers/npcController.js';
+import { applyVisibilityFilter } from '../middleware/visibilityMiddleware.js';
+
+const router = Router();
+
+router.use(applyVisibilityFilter({ requireVisibilityForWrite: true }));
+
+router.get('/', listNpcs);
+router.get('/types', listNpcTypes);
+router.post('/types', createNpcType);
+router.put('/types/:id', updateNpcType);
+router.delete('/types/:id', deleteNpcType);
+router.post('/:id/notes', addNpcNote);
+router.put('/:id/notes/:noteId', updateNpcNote);
+router.delete('/:id/notes/:noteId', deleteNpcNote);
+router.get('/:id', getNpc);
+router.post('/', createNpc);
+router.put('/:id', updateNpc);
+router.delete('/:id', deleteNpc);
+
+export default router;

--- a/backend/src/routes/organisationRoutes.js
+++ b/backend/src/routes/organisationRoutes.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import {
+  listOrganisations,
+  getOrganisation,
+  createOrganisation,
+  updateOrganisation,
+  deleteOrganisation,
+  listOrganisationTypes,
+  createOrganisationType,
+  updateOrganisationType,
+  deleteOrganisationType
+} from '../controllers/organisationController.js';
+import { applyVisibilityFilter } from '../middleware/visibilityMiddleware.js';
+
+const router = Router();
+
+router.use(applyVisibilityFilter({ requireVisibilityForWrite: true }));
+
+router.get('/', listOrganisations);
+router.get('/types', listOrganisationTypes);
+router.post('/types', createOrganisationType);
+router.put('/types/:id', updateOrganisationType);
+router.delete('/types/:id', deleteOrganisationType);
+router.get('/:id', getOrganisation);
+router.post('/', createOrganisation);
+router.put('/:id', updateOrganisation);
+router.delete('/:id', deleteOrganisation);
+
+export default router;

--- a/backend/src/routes/raceRoutes.js
+++ b/backend/src/routes/raceRoutes.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  listRaces,
+  createRace,
+  updateRace,
+  deleteRace
+} from '../controllers/raceController.js';
+import { applyVisibilityFilter } from '../middleware/visibilityMiddleware.js';
+
+const router = Router();
+
+router.use(applyVisibilityFilter({ requireVisibilityForWrite: true }));
+
+router.get('/', listRaces);
+router.post('/', createRace);
+router.put('/:id', updateRace);
+router.delete('/:id', deleteRace);
+
+export default router;

--- a/backend/src/utils/visibility.js
+++ b/backend/src/utils/visibility.js
@@ -1,0 +1,97 @@
+import { Op } from 'sequelize';
+
+export const normalizeVisibilityEntries = (entries = []) => {
+  const seen = new Set();
+  return entries
+    .map((entry) => ({
+      campaign_id: entry?.campaignId ?? entry?.campaign_id ?? null,
+      player_id: entry?.playerId ?? entry?.player_id ?? null
+    }))
+    .filter((entry) => {
+      const key = `${entry.campaign_id || 'null'}:${entry.player_id || 'null'}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+};
+
+export const resolveDefaultVisibility = (context) => {
+  if (!context) return [];
+  if (context.isWorldAdmin) {
+    return [{ campaign_id: null, player_id: null }];
+  }
+  if (context.campaignId) {
+    return [{ campaign_id: context.campaignId, player_id: null }];
+  }
+  if (context.managedCampaignIds?.length) {
+    return context.managedCampaignIds.map((campaignId) => ({ campaign_id: campaignId, player_id: null }));
+  }
+  return context.playerId ? [{ campaign_id: null, player_id: context.playerId }] : [];
+};
+
+export const syncVisibilityEntries = async (Model, keyName, entityId, entries = []) => {
+  const normalized = normalizeVisibilityEntries(entries);
+  await Model.destroy({ where: { [keyName]: entityId } });
+  if (normalized.length === 0) {
+    return [];
+  }
+  const created = await Model.bulkCreate(normalized.map((entry) => ({
+    [keyName]: entityId,
+    campaign_id: entry.campaign_id,
+    player_id: entry.player_id
+  })), { returning: true });
+  return created;
+};
+
+export const buildVisibilityInclude = ({
+  context,
+  model,
+  as,
+  include = []
+}) => {
+  const visibilityInclude = {
+    model,
+    as,
+    include,
+    required: false
+  };
+
+  if (context?.bypassVisibility) {
+    return visibilityInclude;
+  }
+
+  const conditions = [];
+  if (context?.campaignId) {
+    conditions.push({ campaign_id: context.campaignId });
+  }
+  if (context?.playerId) {
+    conditions.push({ player_id: context.playerId });
+  }
+  conditions.push({ campaign_id: null, player_id: null });
+
+  visibilityInclude.where = { [Op.or]: conditions };
+  visibilityInclude.required = true;
+  return visibilityInclude;
+};
+
+export const applyWorldScope = (where = {}, context, field = 'world_id') => {
+  if (!context) return where;
+  if (context.bypassVisibility) {
+    if (context.worldScope?.length) {
+      return { ...where, [field]: context.worldScope.length === 1 ? context.worldScope[0] : { [Op.in]: context.worldScope } };
+    }
+    return where;
+  }
+
+  if (context.worldScope?.length) {
+    return { ...where, [field]: context.worldScope.length === 1 ? context.worldScope[0] : { [Op.in]: context.worldScope } };
+  }
+
+  if (context.worldId) {
+    return { ...where, [field]: context.worldId };
+  }
+
+  return where;
+};


### PR DESCRIPTION
## Summary
- add migrations and Sequelize models for locations, organisations, NPCs, races, and their visibility scaffolding
- implement context-aware visibility middleware plus CRUD controllers with NPC note protections
- expose new API routes that apply character context filtering for world entities

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68e559088868832e8e6e0569e9c78796