### PR TITLE
Convert knowledge directories to table views with filters

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1112,6 +1112,24 @@
   position: relative;
 }
 
+.list-metric {
+  display: flex;
+  align-items: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.list-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.18);
+  color: inherit;
+}
+
 .column-visibility {
   position: relative;
 }
@@ -1128,6 +1146,66 @@
   display: grid;
   gap: 0.5rem;
   z-index: 10;
+}
+
+.list-information {
+  margin-top: -0.5rem;
+}
+
+.list-information p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.list-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.85rem;
+  background: rgba(241, 245, 249, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 180px;
+  flex: 1 1 180px;
+}
+
+.filter-field span {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.filter-field input {
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: #ffffff;
+}
+
+.filter-field input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.filter-actions {
+  display: flex;
+  align-items: flex-end;
+}
+
+.filter-actions button {
+  height: fit-content;
 }
 
 .table-container {
@@ -1156,6 +1234,11 @@
   color: #475569;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.list-note {
+  font-size: 0.85rem;
+  color: #475569;
 }
 
 .table-container tbody tr:hover {


### PR DESCRIPTION
## Summary
- refactor the NPC, location, organisation, and ancestry listings into filterable table views that mirror the user directory experience
- extend the shared StandardList component to support configurable headings, metrics, contextual copy, and multi-column text filters
- add styles for the new table metric chip, filter controls, and contextual messaging shown above and below the tables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5628a1f74832e9f7ea5df44e2e0f4