### PR TITLE
Add relationship management views for NPCs and organisations

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3437,6 +3437,109 @@ button.primary.full-width {
   gap: 0.75rem;
 }
 
+.drawer-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.drawer-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.drawer-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.drawer-allies-enemies {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.relationship-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.relationship-entry {
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.7);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.relationship-entry__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.relationship-entry__label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.relationship-entry__link {
+  border: none;
+  background: none;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.relationship-entry__link:hover {
+  text-decoration: underline;
+}
+
+.relationship-entry__link--disabled {
+  color: rgba(15, 23, 42, 0.5);
+  cursor: default;
+}
+
+.relationship-entry__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.relationship-entry__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  background: rgba(148, 163, 184, 0.28);
+  color: #1f2937;
+}
+
+.relationship-entry__tag--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.relationship-entry__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
 .drawer-subsection {
   border-top: 1px solid rgba(148, 163, 184, 0.3);
   padding-top: 1rem;


### PR DESCRIPTION
## Summary
- add relationship templates, seed data, and persistent state to support cross-entity links between NPCs, organisations, and users
- expose NPC and organisation drawers with relationship listings, navigation, and editing controls
- introduce a reusable relationship manager component, update list view actions, and style the new relationship UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56c8e7de8832e919d73648f702515