### PR TITLE
Switch knowledge selectors to list collectors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1965,6 +1965,8 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.75rem;
+  max-height: calc(100vh - 4rem);
+  overflow: hidden;
 }
 
 .form-modal__header {
@@ -1989,6 +1991,10 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.35rem;
 }
 
 .form-modal__footer {
@@ -2962,6 +2968,65 @@ button.primary.full-width {
 
 .drawer-form textarea {
   resize: vertical;
+}
+
+.list-collector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.list-collector__label {
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.list-collector__control select {
+  width: 100%;
+}
+
+.list-collector__control select:disabled {
+  background: rgba(148, 163, 184, 0.12);
+  color: #64748b;
+  cursor: not-allowed;
+}
+
+.list-collector__pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.list-collector__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.list-collector__pill-remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.list-collector__pill-remove:hover:not(:disabled) {
+  color: #1e40af;
+}
+
+.list-collector__pill-remove:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+  border-radius: 999px;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- replace the campaign and character checkbox fields in knowledge forms with a reusable list collector that adds selections as pills
- update the NPC, location, and organisation drawers to use the new list collector and restore viewer handling for organisations
- limit form modal height so creation dialogs remain scrollable on smaller viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5828bf0e4832eb8266aec835fb459