### PR TITLE
Add reference field and tabbed dossiers to knowledge records

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1957,7 +1957,7 @@
 
 .form-modal {
   position: relative;
-  width: min(420px, 100%);
+  width: min(520px, calc(100vw - 2rem));
   background: #ffffff;
   border-radius: 1.25rem;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.2);
@@ -1967,6 +1967,24 @@
   padding: 1.75rem;
   max-height: calc(100vh - 4rem);
   overflow: hidden;
+}
+
+.form-modal--md {
+  width: min(520px, calc(100vw - 2rem));
+}
+
+.form-modal--lg {
+  width: min(720px, calc(100vw - 2rem));
+}
+
+@media (min-width: 768px) {
+  .form-modal--md {
+    width: min(580px, calc(100vw - 4rem));
+  }
+
+  .form-modal--lg {
+    width: min(780px, calc(100vw - 4rem));
+  }
 }
 
 .form-modal__header {
@@ -2089,7 +2107,9 @@
     align-items: flex-end;
   }
 
-  .form-modal {
+  .form-modal,
+  .form-modal--md,
+  .form-modal--lg {
     width: 100%;
   }
 }
@@ -2954,7 +2974,8 @@ button.primary.full-width {
 }
 
 .drawer-form.drawer-form--columns label,
-.drawer-form.drawer-form--columns .list-collector {
+.drawer-form.drawer-form--columns .list-collector,
+.drawer-form.drawer-form--columns .reference-field {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -2987,6 +3008,104 @@ button.primary.full-width {
   resize: vertical;
 }
 
+.reference-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  position: relative;
+}
+
+.reference-field__label {
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.reference-field__control {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.reference-field__input {
+  width: 100%;
+  padding-right: 2.75rem;
+}
+
+.reference-field__clear {
+  position: absolute;
+  right: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.reference-field__clear:hover,
+.reference-field__clear:focus-visible {
+  color: #1d4ed8;
+}
+
+.reference-field__chevron {
+  position: absolute;
+  right: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.9rem;
+  color: #64748b;
+  pointer-events: none;
+}
+
+.reference-field__options {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 0.3rem 0;
+  margin: 0;
+  list-style: none;
+  background: #ffffff;
+  border-radius: 0.85rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.15);
+  z-index: 8;
+}
+
+.reference-field__option {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 0.5rem 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.reference-field__option--active,
+.reference-field__option:hover {
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.reference-field__option--empty {
+  padding: 0.6rem 0.85rem;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.reference-field--disabled .reference-field__clear {
+  display: none;
+}
+
+.reference-field--disabled .reference-field__chevron {
+  color: #94a3b8;
+}
+
 .list-collector {
   display: flex;
   flex-direction: column;
@@ -2998,14 +3117,8 @@ button.primary.full-width {
   color: #0f172a;
 }
 
-.list-collector__control select {
-  width: 100%;
-}
-
-.list-collector__control select:disabled {
-  background: rgba(148, 163, 184, 0.12);
-  color: #64748b;
-  cursor: not-allowed;
+.list-collector .reference-field__options {
+  z-index: 9;
 }
 
 .list-collector__pill-row {
@@ -3517,6 +3630,48 @@ button.primary.full-width {
 .knowledge-relationships {
   display: grid;
   gap: 0.75rem;
+}
+
+.drawer-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.drawer-tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.drawer-tabs__tab {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.6);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.drawer-tabs__tab:hover,
+.drawer-tabs__tab:focus-visible {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.4);
+  color: #1d4ed8;
+}
+
+.drawer-tabs__tab--active {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #1d4ed8;
+}
+
+.drawer-tabs__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .drawer-stack {


### PR DESCRIPTION
## Summary
- add a reusable reference field component and switch NPC list collectors and location selectors to use it
- widen the Add NPC modal on larger screens and introduce tabbed dossiers for NPC, location, and organisation drawers with dedicated DM controls and relationships views
- enable relationship management for locations by wiring focus handling, navigation, and entity directory support
- update styling to support the new reference picker and drawer tabs

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e60f8a3cec832eb1516cf50b42c24d