### PR TITLE
Fix syntax error in App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -287,8 +287,6 @@ const capabilityMatrix = {
   }
 }
 
-}
-
 const classNames = (...values) => values.filter(Boolean).join(' ')
 
 const statusVariantFromStatus = (status) => {


### PR DESCRIPTION
## Summary
- remove a stray closing brace left behind during the refactor
- restore App.jsx parsing so the Vite dev server can compile again

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e62663cb14832e9efa3d5ff2eab8bb