### PR TITLE
feat: add auth and data context providers

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import './App.css'
 import { readStoredState, writeStoredState } from './utils/storage'
 import { newId } from './utils/idGenerator'
+import { AuthProvider } from './context/AuthContext'
+import { DataProvider } from './context/DataContext'
 import {
   seededRoles,
   seededUsers,
@@ -2853,7 +2855,7 @@ function RaceLibrary({
   )
 }
 
-function App() {
+function AppContent() {
   const storedState = useMemo(() => readStoredState(STORAGE_KEY, null), [])
   const [session, setSession] = useState(() => {
     const savedSession =
@@ -8636,4 +8638,12 @@ function RecordDrawer({ open, title, subtitle, onClose, actions, children }) {
   )
 }
 
-export default App
+export default function App() {
+  return (
+    <AuthProvider>
+      <DataProvider>
+        <AppContent />
+      </DataProvider>
+    </AuthProvider>
+  )
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import { readStoredState, writeStoredState } from '../utils/storage';
+
+const AuthContext = createContext();
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }) {
+  const [currentUser, setCurrentUser] = useState(() =>
+    readStoredState('currentUser', null)
+  );
+
+  const login = (user) => {
+    setCurrentUser(user);
+    writeStoredState('currentUser', user);
+  };
+
+  const logout = () => {
+    setCurrentUser(null);
+    localStorage.removeItem('currentUser');
+  };
+
+  const isSystemAdmin =
+    currentUser?.roles?.some((r) => r.toLowerCase().includes('admin')) ?? false;
+
+  const value = { currentUser, login, logout, isSystemAdmin };
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/context/DataContext.jsx
+++ b/frontend/src/context/DataContext.jsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import { readStoredState, writeStoredState } from '../utils/storage';
+import {
+  seededRoles,
+  seededUsers,
+  seededWorlds,
+  seededCampaigns,
+  seededCharacters,
+  seededNpcs,
+  seededLocations,
+  seededOrganisations,
+  seededRelationships,
+  seededRelationshipTypes,
+  seededRaces,
+} from '../constants/seedData';
+
+const DataContext = createContext();
+export const useData = () => useContext(DataContext);
+
+export function DataProvider({ children }) {
+  // initialise from localStorage or seed data
+  const [roles, setRoles] = useState(() => readStoredState('roles', seededRoles));
+  const [users, setUsers] = useState(() => readStoredState('users', seededUsers));
+  const [worlds, setWorlds] = useState(() => readStoredState('worlds', seededWorlds));
+  const [campaigns, setCampaigns] = useState(() => readStoredState('campaigns', seededCampaigns));
+  const [characters, setCharacters] = useState(() => readStoredState('characters', seededCharacters));
+  const [npcs, setNpcs] = useState(() => readStoredState('npcs', seededNpcs));
+  const [locations, setLocations] = useState(() => readStoredState('locations', seededLocations));
+  const [organisations, setOrganisations] = useState(() => readStoredState('organisations', seededOrganisations));
+  const [relationships, setRelationships] = useState(() => readStoredState('relationships', seededRelationships));
+  const [relationshipTypes, setRelationshipTypes] = useState(() => readStoredState('relationshipTypes', seededRelationshipTypes));
+  const [races, setRaces] = useState(() => readStoredState('races', seededRaces));
+
+  // auto-persist on change
+  useEffect(() => {
+    writeStoredState('roles', roles);
+    writeStoredState('users', users);
+    writeStoredState('worlds', worlds);
+    writeStoredState('campaigns', campaigns);
+    writeStoredState('characters', characters);
+    writeStoredState('npcs', npcs);
+    writeStoredState('locations', locations);
+    writeStoredState('organisations', organisations);
+    writeStoredState('relationships', relationships);
+    writeStoredState('relationshipTypes', relationshipTypes);
+    writeStoredState('races', races);
+  }, [roles, users, worlds, campaigns, characters, npcs, locations, organisations, relationships, relationshipTypes, races]);
+
+  // sample CRUDs (expand later)
+  const saveWorld = (world) => setWorlds((prev) => [...prev.filter(w => w.id !== world.id), world]);
+  const deleteWorld = (id) => setWorlds((prev) => prev.filter((w) => w.id !== id));
+
+  const value = {
+    roles, users, worlds, campaigns, characters, npcs,
+    locations, organisations, relationships, relationshipTypes, races,
+    saveWorld, deleteWorld,
+  };
+
+  return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
+}


### PR DESCRIPTION
## Summary
- add an authentication context to manage login state and system admin detection
- introduce a shared data context seeded from storage to persist world and campaign data
- wrap the app with the new providers so future components can consume the contexts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e628172a80832e92703e17e3ff27a9