### PR TITLE
Restore responsive sidebar layout

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,9 +1,62 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import Header from './Header'
 import Sidebar from './Sidebar'
 
+const PIN_STORAGE_KEY = 'dnd-app:sidebar-pinned'
+const COLLAPSE_STORAGE_KEY = 'dnd-app:sidebar-collapsed'
+
+function readStoredBoolean(key, fallback) {
+  if (typeof window === 'undefined') return fallback
+  try {
+    const value = window.localStorage.getItem(key)
+    if (value === null) return fallback
+    return value === 'true'
+  } catch (error) {
+    console.warn('Unable to read sidebar preference', error)
+    return fallback
+  }
+}
+
+function writeStoredBoolean(key, value) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(key, value ? 'true' : 'false')
+  } catch (error) {
+    console.warn('Unable to persist sidebar preference', error)
+  }
+}
+
+function useMediaQuery(query, fallback = false) {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return fallback
+    }
+    return window.matchMedia(query).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+    const mediaQueryList = window.matchMedia(query)
+    const updateMatch = () => setMatches(mediaQueryList.matches)
+    updateMatch()
+    mediaQueryList.addEventListener('change', updateMatch)
+    return () => mediaQueryList.removeEventListener('change', updateMatch)
+  }, [query])
+
+  return matches
+}
+
 export default function AppLayout({ children }) {
   const headerRef = useRef(null)
+  const location = useLocation()
+  const isCompactLayout = useMediaQuery('(max-width: 960px)')
+
+  const [sidebarPinned, setSidebarPinned] = useState(() => readStoredBoolean(PIN_STORAGE_KEY, true))
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => readStoredBoolean(COLLAPSE_STORAGE_KEY, false))
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   useEffect(() => {
     const updateHeaderHeight = () => {
@@ -20,13 +73,65 @@ export default function AppLayout({ children }) {
     }
   }, [])
 
+  useEffect(() => {
+    if (!isCompactLayout) {
+      setIsMobileMenuOpen(false)
+    }
+  }, [isCompactLayout])
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false)
+  }, [location.pathname])
+
+  useEffect(() => {
+    writeStoredBoolean(PIN_STORAGE_KEY, sidebarPinned)
+  }, [sidebarPinned])
+
+  useEffect(() => {
+    writeStoredBoolean(COLLAPSE_STORAGE_KEY, sidebarCollapsed)
+  }, [sidebarCollapsed])
+
+  const effectiveCollapsed = useMemo(() => {
+    if (isCompactLayout) return false
+    return sidebarCollapsed
+  }, [isCompactLayout, sidebarCollapsed])
+
+  const handleTogglePinned = () => {
+    setSidebarPinned((prev) => !prev)
+  }
+
+  const handleToggleCollapsed = () => {
+    setSidebarCollapsed((prev) => !prev)
+  }
+
+  const handleOpenMobileMenu = () => {
+    setIsMobileMenuOpen(true)
+  }
+
+  const handleCloseMobileMenu = () => {
+    setIsMobileMenuOpen(false)
+  }
+
   return (
     <div className="app-shell">
       <div className="app-body">
-        <Sidebar />
+        <Sidebar
+          isPinned={sidebarPinned}
+          isCollapsed={effectiveCollapsed}
+          isCompactLayout={isCompactLayout}
+          isMobileOpen={isMobileMenuOpen}
+          onPinToggle={handleTogglePinned}
+          onCollapseToggle={handleToggleCollapsed}
+          onRequestClose={handleCloseMobileMenu}
+        />
         <div className="shell-main">
           <div ref={headerRef}>
-            <Header />
+            <Header
+              isCompactLayout={isCompactLayout}
+              isSidebarCollapsed={effectiveCollapsed}
+              onRequestMobileMenu={handleOpenMobileMenu}
+              onRequestCollapseToggle={handleToggleCollapsed}
+            />
           </div>
           <main className="module-content">{children}</main>
         </div>

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,31 +1,172 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
 import { useData } from '../../context/DataContext'
 
-export default function Header() {
+function getInitials(name) {
+  if (!name) return 'DA'
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+  if (parts.length === 0) return 'DA'
+  return parts
+    .map((part) => part[0].toUpperCase())
+    .join('')
+}
+
+export default function Header({
+  isCompactLayout,
+  isSidebarCollapsed,
+  onRequestMobileMenu,
+  onRequestCollapseToggle,
+}) {
   const { currentUser, logout } = useAuth()
   const { campaigns = [], characters = [] } = useData()
+  const [isProfileOpen, setIsProfileOpen] = useState(false)
+  const menuRef = useRef(null)
 
-  const displayName = currentUser?.name || currentUser?.username || 'Unknown'
+  const displayName = currentUser?.name || currentUser?.username || 'Unknown Adventurer'
   const title = currentUser?.roleNames?.[0] || 'Adventurer'
   const status = currentUser?.status || 'Active'
-  const dataSummary = `${campaigns.length} campaigns · ${characters.length} characters`
+  const dataSummary = useMemo(
+    () => `${campaigns.length} campaigns · ${characters.length} characters`,
+    [campaigns.length, characters.length],
+  )
+  const initials = getInitials(displayName)
+
+  useEffect(() => {
+    if (!isProfileOpen) return
+    const handleClickOutside = (event) => {
+      if (!menuRef.current || menuRef.current.contains(event.target)) return
+      setIsProfileOpen(false)
+    }
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setIsProfileOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('touchstart', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('touchstart', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isProfileOpen])
+
+  const handleLogout = () => {
+    setIsProfileOpen(false)
+    logout()
+  }
+
+  const collapseLabel = isSidebarCollapsed ? 'Expand menu' : 'Collapse menu'
+  const collapseIcon = isSidebarCollapsed ? '⤢' : '⤡'
 
   return (
-    <header className="app-header flex items-center justify-between p-2 bg-gray-900 text-white">
-      <div className="flex items-center space-x-2">
-        <h1 className="text-lg font-bold cursor-pointer">DnD App</h1>
-        <span className="text-sm opacity-75" title={dataSummary}>
-          {title} ({status})
-        </span>
-      </div>
-      <div className="flex items-center space-x-3">
-        <span>{displayName}</span>
-        <button
-          onClick={logout}
-          className="text-sm px-2 py-1 bg-red-700 rounded hover:bg-red-600"
-        >
-          Logout
-        </button>
+    <header className="app-header">
+      <div className="header-bar">
+        <div className="brand-identity">
+          {isCompactLayout && (
+            <button
+              type="button"
+              className="icon-button"
+              onClick={onRequestMobileMenu}
+              aria-label="Open navigation"
+            >
+              <span aria-hidden>☰</span>
+            </button>
+          )}
+          <Link to="/" className="brand-home-link">
+            <span className="brand-logo">
+              <span aria-hidden>DA</span>
+            </span>
+            <span className="brand-copy">
+              <span className="brand-title">DnD Atlas</span>
+              <span className="brand-subtitle">Campaign control center</span>
+            </span>
+          </Link>
+        </div>
+
+        <div className="header-actions">
+          {!isCompactLayout && (
+            <button
+              type="button"
+              className={`sidebar-pin-inline${isSidebarCollapsed ? '' : ' active'}`}
+              onClick={onRequestCollapseToggle}
+            >
+              <span className="sidebar-pin-icon" aria-hidden>
+                {collapseIcon}
+              </span>
+              <span className="sidebar-pin-label">{collapseLabel}</span>
+            </button>
+          )}
+
+          <div className="context-switchers" aria-live="polite">
+            <div className="context-select">
+              <span>Campaigns</span>
+              <strong>{campaigns.length}</strong>
+            </div>
+            <div className="context-select">
+              <span>Characters</span>
+              <strong>{characters.length}</strong>
+            </div>
+          </div>
+
+          <div className="current-user-menu" ref={menuRef}>
+            <button
+              type="button"
+              className="current-user-button"
+              onClick={() => setIsProfileOpen((prev) => !prev)}
+              aria-expanded={isProfileOpen}
+              aria-haspopup="true"
+            >
+              <span className="user-avatar" aria-hidden>
+                {initials}
+              </span>
+              <span className="user-meta">
+                <span className="user-name">{displayName}</span>
+                <span className="user-role">{title}</span>
+              </span>
+            </button>
+
+            {isProfileOpen && (
+              <div className="profile-dropdown" role="menu">
+                <div className="profile-overview">
+                  <span className="profile-overview-name">{displayName}</span>
+                  <span className="profile-overview-role">{title}</span>
+                  {currentUser?.email && (
+                    <span className="profile-overview-email">{currentUser.email}</span>
+                  )}
+                  <div className="profile-overview-status">
+                    <span className="status-pill">{status}</span>
+                    <span>{dataSummary}</span>
+                  </div>
+                </div>
+                <div className="profile-actions">
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => setIsProfileOpen(false)}
+                  >
+                    Close
+                  </button>
+                  <button
+                    type="button"
+                    className="primary destructive"
+                    onClick={handleLogout}
+                  >
+                    Logout
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </header>
   )

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,34 +1,148 @@
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { NavLink } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
 
-export default function Sidebar() {
+const NAVIGATION_ITEMS = [
+  { path: '/', label: 'Home', icon: '🏠' },
+  { path: '/worlds', label: 'Worlds', icon: '🌍' },
+  { path: '/campaigns', label: 'Campaigns', icon: '🗺️' },
+  { path: '/characters', label: 'Characters', icon: '🧙' },
+  { path: '/npcs', label: 'NPCs', icon: '🧝' },
+  { path: '/locations', label: 'Locations', icon: '📍' },
+  { path: '/organisations', label: 'Organisations', icon: '🏛️' },
+  { path: '/races', label: 'Races', icon: '🐉' },
+]
+
+function classNames(...values) {
+  return values.filter(Boolean).join(' ')
+}
+
+export default function Sidebar({
+  isPinned,
+  isCollapsed,
+  isCompactLayout,
+  isMobileOpen,
+  onPinToggle,
+  onCollapseToggle,
+  onRequestClose,
+}) {
   const { currentUser } = useAuth()
-  const roles = currentUser?.roleNames || []
+  const [isHovering, setIsHovering] = useState(false)
 
-  const links = [
-    { path: '/', label: 'Home' },
-    { path: '/worlds', label: 'Worlds' },
-    { path: '/campaigns', label: 'Campaigns' },
-    { path: '/characters', label: 'Characters' },
-    { path: '/npcs', label: 'NPCs' },
-    { path: '/locations', label: 'Locations' },
-    { path: '/organisations', label: 'Organisations' },
-    { path: '/races', label: 'Races' },
-  ]
-
-  if (roles.includes('System Administrator')) {
-    links.push({ path: '/admin', label: 'Admin' })
+  const links = [...NAVIGATION_ITEMS]
+  if (currentUser?.roleNames?.includes('System Administrator')) {
+    links.push({ path: '/admin', label: 'Admin', icon: '🛡️' })
   }
 
+  const shouldCollapse = isCollapsed && !(isHovering && !isPinned)
+  const sidebarClassName = classNames(
+    'shell-sidebar',
+    !isPinned && 'sidebar-floating',
+    shouldCollapse && 'sidebar-collapsed',
+    isMobileOpen && 'sidebar-mobile-open',
+  )
+
+  const handleMouseEnter = () => {
+    if (!isPinned && isCollapsed) {
+      setIsHovering(true)
+    }
+  }
+
+  const handleMouseLeave = () => {
+    if (!isPinned && isCollapsed) {
+      setIsHovering(false)
+    }
+  }
+
+  const handleLinkClick = () => {
+    if (isCompactLayout) {
+      onRequestClose?.()
+    }
+  }
+
+  const sidebarLabel = isPinned ? 'Sidebar pinned' : 'Sidebar floating'
+  const collapseButtonLabel = shouldCollapse ? 'Expand navigation' : 'Collapse navigation'
+
   return (
-    <aside className="app-sidebar bg-gray-800 text-white w-56 p-3">
-      <nav className="flex flex-col space-y-2">
-        {links.map((link) => (
-          <Link key={link.path} to={link.path} className="hover:bg-gray-700 rounded px-2 py-1">
-            {link.label}
-          </Link>
-        ))}
-      </nav>
-    </aside>
+    <>
+      <aside
+        className={sidebarClassName}
+        aria-label="Primary"
+        data-sidebar-state={sidebarLabel}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <div className="sidebar-brand">
+          <span className="sidebar-logo" aria-hidden>
+            DA
+          </span>
+          <div className="sidebar-copy">
+            <span className="sidebar-title">Dungeons &amp; Data</span>
+            <small>Campaign control center</small>
+          </div>
+          {!isCompactLayout && (
+            <button
+              type="button"
+              className={classNames('icon-button', 'sidebar-pin-toggle', isPinned && 'active')}
+              onClick={onPinToggle}
+              aria-pressed={isPinned}
+              aria-label={isPinned ? 'Unpin sidebar' : 'Pin sidebar'}
+            >
+              <span aria-hidden>{isPinned ? '📌' : '📍'}</span>
+            </button>
+          )}
+          {isCompactLayout && (
+            <button
+              type="button"
+              className="icon-button sidebar-close"
+              onClick={onRequestClose}
+              aria-label="Close navigation"
+            >
+              <span aria-hidden>✕</span>
+            </button>
+          )}
+        </div>
+
+        {!isCompactLayout && (
+          <button
+            type="button"
+            className={classNames('sidebar-pin-inline', shouldCollapse && 'active')}
+            onClick={onCollapseToggle}
+          >
+            <span className="sidebar-pin-icon" aria-hidden>
+              {shouldCollapse ? '⤢' : '⤡'}
+            </span>
+            <span className="sidebar-pin-label">{collapseButtonLabel}</span>
+          </button>
+        )}
+
+        <nav className="sidebar-nav">
+          {links.map((link) => (
+            <NavLink
+              key={link.path}
+              to={link.path}
+              className={({ isActive }) =>
+                classNames('sidebar-link', isActive && 'active')
+              }
+              onClick={handleLinkClick}
+            >
+              <span className="sidebar-icon" aria-hidden>
+                {link.icon || link.label.charAt(0)}
+              </span>
+              <span className="sidebar-label">{link.label}</span>
+            </NavLink>
+          ))}
+          {links.length === 0 && <p className="sidebar-empty">No modules available</p>}
+        </nav>
+      </aside>
+      {isCompactLayout && isMobileOpen && (
+        <button
+          type="button"
+          className="sidebar-backdrop"
+          aria-label="Close navigation"
+          onClick={onRequestClose}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- reintroduce responsive sidebar state management with persisted pin and collapse preferences
- rebuild the sidebar markup to match the design system and support mobile toggling
- refresh the header layout with campaign context and profile dropdown controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e64c5d2560832eb074e0f0b3f53e19