### PR TITLE
Connect front-end directories to API data

### DIFF
--- a/frontend/src/context/DataContext.jsx
+++ b/frontend/src/context/DataContext.jsx
@@ -1,20 +1,86 @@
-import { createContext, useContext, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useAuth } from './AuthContext'
 
-const DataContext = createContext({
-  campaigns: [],
-  characters: [],
-})
+const DataContext = createContext(null)
 
 export function DataProvider({ children }) {
+  const api = useApiClient()
+  const { token } = useAuth()
+
+  const [worlds, setWorlds] = useState([])
+  const [worldsLoading, setWorldsLoading] = useState(false)
+  const [worldsError, setWorldsError] = useState(null)
+  const [activeWorldId, setActiveWorldId] = useState(null)
+
   const [campaigns] = useState([])
   const [characters] = useState([])
 
+  const loadWorlds = useCallback(async ({ signal } = {}) => {
+    if (!token) {
+      setWorlds([])
+      setActiveWorldId(null)
+      setWorldsError(null)
+      setWorldsLoading(false)
+      return
+    }
+
+    setWorldsLoading(true)
+    try {
+      const data = await api.get('/worlds', { signal })
+      const list = Array.isArray(data) ? data : []
+      if (signal?.aborted) return
+      setWorlds(list)
+      setWorldsError(null)
+      setActiveWorldId((prev) => {
+        if (prev && list.some((world) => world.id === prev)) {
+          return prev
+        }
+        return list[0]?.id ?? null
+      })
+    } catch (error) {
+      if (signal?.aborted) return
+      console.error('Failed to load worlds', error)
+      setWorlds([])
+      setWorldsError(error)
+      setActiveWorldId(null)
+    } finally {
+      if (!signal?.aborted) {
+        setWorldsLoading(false)
+      }
+    }
+  }, [api, token])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    loadWorlds({ signal: controller.signal })
+
+    return () => {
+      controller.abort()
+    }
+  }, [loadWorlds])
+
   const value = useMemo(
     () => ({
+      worlds,
+      worldsLoading,
+      worldsError,
+      activeWorldId,
+      setActiveWorldId,
+      refreshWorlds: loadWorlds,
       campaigns,
       characters,
     }),
-    [campaigns, characters],
+    [
+      worlds,
+      worldsLoading,
+      worldsError,
+      activeWorldId,
+      loadWorlds,
+      campaigns,
+      characters,
+    ],
   )
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>

--- a/frontend/src/pages/CharactersPage.jsx
+++ b/frontend/src/pages/CharactersPage.jsx
@@ -1,7 +1,138 @@
+import { useEffect, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+
+const tableStyle = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  marginTop: '1.5rem',
+  backgroundColor: '#fff',
+  borderRadius: '12px',
+  overflow: 'hidden',
+  boxShadow: '0 12px 22px rgba(15, 23, 42, 0.08)',
+}
+
+const headerCellStyle = {
+  textAlign: 'left',
+  padding: '0.85rem 1rem',
+  backgroundColor: '#0f172a',
+  color: '#f8fafc',
+  fontWeight: 600,
+  fontSize: '0.9rem',
+}
+
+const cellStyle = {
+  padding: '0.85rem 1rem',
+  borderBottom: '1px solid #e2e8f0',
+  verticalAlign: 'top',
+  fontSize: '0.95rem',
+  color: '#1f2937',
+}
+
 export default function CharactersPage() {
+  const api = useApiClient()
+  const [characters, setCharacters] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/characters', { signal: controller.signal })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setCharacters(Array.isArray(data) ? data : [])
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load characters', err)
+        setError(err)
+        setCharacters([])
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api])
+
   return (
-    <div>
-      <h1>Characters</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>Characters</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Review the adventurers in your roster, their levels, classes, and campaign
+            assignments.
+          </p>
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {loading && <p>Loading characters…</p>}
+        {!loading && error && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load characters: {error.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !error && (
+          <>
+            {characters.length === 0 ? (
+              <div
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '12px',
+                  padding: '1.25rem 1.5rem',
+                  backgroundColor: '#f8fafc',
+                }}
+              >
+                <p style={{ margin: 0 }}>No characters found for your account.</p>
+              </div>
+            ) : (
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={{ ...headerCellStyle, width: '22%' }}>Character</th>
+                    <th style={{ ...headerCellStyle, width: '15%' }}>Owner</th>
+                    <th style={{ ...headerCellStyle, width: '12%' }}>Level</th>
+                    <th style={headerCellStyle}>Class</th>
+                    <th style={{ ...headerCellStyle, width: '20%' }}>Campaigns</th>
+                    <th style={{ ...headerCellStyle, width: '10%' }}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {characters.map((character) => (
+                    <tr key={character.id}>
+                      <td style={cellStyle}>
+                        <strong>{character.name}</strong>
+                        {character.description && (
+                          <div style={{ marginTop: '0.35rem', color: '#475569', fontSize: '0.85rem' }}>
+                            {character.description}
+                          </div>
+                        )}
+                      </td>
+                      <td style={cellStyle}>{character.owner?.username || 'Unassigned'}</td>
+                      <td style={cellStyle}>{character.level ?? '—'}</td>
+                      <td style={cellStyle}>{character.class || 'Unknown'}</td>
+                      <td style={cellStyle}>
+                        {character.campaigns?.length
+                          ? character.campaigns.map((campaign) => campaign.name).join(', ')
+                          : 'No campaigns'}
+                      </td>
+                      <td style={cellStyle}>{character.active ? 'Active' : 'Inactive'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }

--- a/frontend/src/pages/LocationsAtlas.jsx
+++ b/frontend/src/pages/LocationsAtlas.jsx
@@ -1,7 +1,224 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
+
+const tableStyle = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  marginTop: '1rem',
+  backgroundColor: '#fff',
+  borderRadius: '12px',
+  overflow: 'hidden',
+  boxShadow: '0 12px 22px rgba(15, 23, 42, 0.08)',
+}
+
+const headerCellStyle = {
+  textAlign: 'left',
+  padding: '0.85rem 1rem',
+  backgroundColor: '#0f172a',
+  color: '#f8fafc',
+  fontWeight: 600,
+  fontSize: '0.9rem',
+}
+
+const cellStyle = {
+  padding: '0.85rem 1rem',
+  borderBottom: '1px solid #e2e8f0',
+  verticalAlign: 'top',
+  fontSize: '0.95rem',
+  color: '#1f2937',
+}
+
+const emptyStateStyle = {
+  marginTop: '1.5rem',
+  padding: '1.25rem 1.5rem',
+  backgroundColor: '#f8fafc',
+  border: '1px solid #e2e8f0',
+  borderRadius: '12px',
+}
+
+const selectStyle = {
+  borderRadius: '0.75rem',
+  border: '1px solid #cbd5f5',
+  padding: '0.45rem 0.75rem',
+  minWidth: '12rem',
+  backgroundColor: '#fff',
+}
+
+const formatVisibility = (entries = []) => {
+  if (!entries.length) {
+    return 'No visibility rules defined'
+  }
+
+  const labels = entries.map((entry) => {
+    if (!entry.campaign_id && !entry.player_id) {
+      return 'Public'
+    }
+    if (entry.campaign?.name) {
+      return `Campaign: ${entry.campaign.name}`
+    }
+    if (entry.player?.username) {
+      return `Player: ${entry.player.username}`
+    }
+    return 'Restricted'
+  })
+
+  const uniqueLabels = [...new Set(labels)]
+  return uniqueLabels.join(', ')
+}
+
 export default function LocationsAtlas() {
+  const api = useApiClient()
+  const {
+    worlds,
+    worldsLoading,
+    worldsError,
+    activeWorldId,
+    setActiveWorldId,
+  } = useData()
+
+  const [locations, setLocations] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!activeWorldId) {
+      setLocations([])
+      return
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/locations', {
+        context: { worldId: activeWorldId },
+        signal: controller.signal,
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setLocations(Array.isArray(data) ? data : [])
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load locations', err)
+        setLocations([])
+        setError(err)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api, activeWorldId])
+
+  const activeWorldName = useMemo(() => {
+    if (!activeWorldId) return null
+    return worlds.find((world) => world.id === activeWorldId)?.name ?? null
+  }, [activeWorldId, worlds])
+
+  const handleWorldChange = (event) => {
+    setActiveWorldId(event.target.value || null)
+  }
+
   return (
-    <div>
-      <h1>Locations</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>
+            Locations atlas
+          </h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Explore the settlements, regions, and points of interest available to the
+            currently selected world.
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.75rem',
+            alignItems: 'center',
+          }}
+        >
+          <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+            <span style={{ fontWeight: 600, color: '#1f2937' }}>World context</span>
+            <select
+              value={activeWorldId ?? ''}
+              onChange={handleWorldChange}
+              disabled={worldsLoading || !!worldsError}
+              style={selectStyle}
+            >
+              {worlds.map((world) => (
+                <option key={world.id} value={world.id}>
+                  {world.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {activeWorldName && (
+            <span style={{ fontSize: '0.9rem', color: '#1f2937' }}>
+              Showing locations for <strong>{activeWorldName}</strong>
+            </span>
+          )}
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {(worldsLoading || loading) && <p>Loading locations…</p>}
+        {!loading && !worldsLoading && (error || worldsError) && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load locations:{' '}
+            {worldsError?.message || error?.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !worldsLoading && !error && !worldsError && (
+          <>
+            {locations.length === 0 ? (
+              <div style={emptyStateStyle}>
+                <p style={{ margin: 0 }}>
+                  No locations were returned for this world. Try seeding some content or
+                  adjust the visibility filters for your campaigns.
+                </p>
+              </div>
+            ) : (
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={{ ...headerCellStyle, width: '20%' }}>Name</th>
+                    <th style={{ ...headerCellStyle, width: '15%' }}>Type</th>
+                    <th style={headerCellStyle}>Summary</th>
+                    <th style={{ ...headerCellStyle, width: '25%' }}>Visibility</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {locations.map((location) => (
+                    <tr key={location.id}>
+                      <td style={cellStyle}>
+                        <strong>{location.name}</strong>
+                        {location.organisations?.length ? (
+                          <div style={{ marginTop: '0.35rem', fontSize: '0.8rem', color: '#475569' }}>
+                            Linked organisations: {location.organisations.length}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td style={cellStyle}>{location.type?.name || 'Uncategorised'}</td>
+                      <td style={cellStyle}>
+                        {location.summary || location.description || 'No summary provided.'}
+                      </td>
+                      <td style={cellStyle}>{formatVisibility(location.visibility)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }

--- a/frontend/src/pages/NpcDirectory.jsx
+++ b/frontend/src/pages/NpcDirectory.jsx
@@ -1,7 +1,239 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
+
+const directoryStyle = {
+  display: 'grid',
+  gap: '1rem',
+  marginTop: '1.5rem',
+}
+
+const cardStyle = {
+  backgroundColor: '#ffffff',
+  borderRadius: '14px',
+  border: '1px solid #e2e8f0',
+  padding: '1.1rem 1.3rem',
+  boxShadow: '0 12px 20px rgba(15, 23, 42, 0.08)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.65rem',
+}
+
+const metaLineStyle = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+  fontSize: '0.85rem',
+  color: '#334155',
+}
+
+const badgeStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  padding: '0.25rem 0.6rem',
+  borderRadius: '9999px',
+  backgroundColor: '#e0f2fe',
+  color: '#0369a1',
+  fontWeight: 600,
+  fontSize: '0.75rem',
+}
+
+const visibilityBadgeStyle = {
+  ...badgeStyle,
+  backgroundColor: '#ede9fe',
+  color: '#5b21b6',
+}
+
+const selectStyle = {
+  borderRadius: '0.75rem',
+  border: '1px solid #cbd5f5',
+  padding: '0.45rem 0.75rem',
+  minWidth: '12rem',
+  backgroundColor: '#fff',
+}
+
+const formatVisibility = (entries = []) => {
+  if (!entries.length) return ['Public']
+
+  const labels = entries.map((entry) => {
+    if (!entry.campaign_id && !entry.player_id) {
+      return 'Public'
+    }
+    if (entry.campaign?.name) {
+      return `Campaign: ${entry.campaign.name}`
+    }
+    if (entry.player?.username) {
+      return `Player: ${entry.player.username}`
+    }
+    return 'Restricted'
+  })
+
+  return [...new Set(labels)]
+}
+
 export default function NpcDirectory() {
+  const api = useApiClient()
+  const {
+    worlds,
+    worldsLoading,
+    worldsError,
+    activeWorldId,
+    setActiveWorldId,
+  } = useData()
+
+  const [npcs, setNpcs] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!activeWorldId) {
+      setNpcs([])
+      return
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/npcs', {
+        context: { worldId: activeWorldId },
+        signal: controller.signal,
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setNpcs(Array.isArray(data) ? data : [])
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load NPCs', err)
+        setError(err)
+        setNpcs([])
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api, activeWorldId])
+
+  const activeWorldName = useMemo(() => {
+    if (!activeWorldId) return null
+    return worlds.find((world) => world.id === activeWorldId)?.name ?? null
+  }, [activeWorldId, worlds])
+
+  const handleWorldChange = (event) => {
+    setActiveWorldId(event.target.value || null)
+  }
+
   return (
-    <div>
-      <h1>NPC Directory</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>NPC directory</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Keep track of allies, rivals, and notable figures for the selected world.
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.75rem',
+            alignItems: 'center',
+          }}
+        >
+          <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+            <span style={{ fontWeight: 600, color: '#1f2937' }}>World context</span>
+            <select
+              value={activeWorldId ?? ''}
+              onChange={handleWorldChange}
+              disabled={worldsLoading || !!worldsError}
+              style={selectStyle}
+            >
+              {worlds.map((world) => (
+                <option key={world.id} value={world.id}>
+                  {world.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {activeWorldName && (
+            <span style={{ fontSize: '0.9rem', color: '#1f2937' }}>
+              Showing NPCs for <strong>{activeWorldName}</strong>
+            </span>
+          )}
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {(worldsLoading || loading) && <p>Loading NPCs…</p>}
+        {!loading && !worldsLoading && (error || worldsError) && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load NPCs: {worldsError?.message || error?.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !worldsLoading && !error && !worldsError && (
+          <>
+            {npcs.length === 0 ? (
+              <div
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '12px',
+                  padding: '1.25rem 1.5rem',
+                  backgroundColor: '#f8fafc',
+                }}
+              >
+                <p style={{ margin: 0 }}>
+                  No NPCs were returned for this world. Create one or adjust visibility
+                  permissions to make them available.
+                </p>
+              </div>
+            ) : (
+              <div style={directoryStyle}>
+                {npcs.map((npc) => (
+                  <article key={npc.id} style={cardStyle}>
+                    <header>
+                      <h2 style={{ margin: 0, fontSize: '1.2rem' }}>{npc.name}</h2>
+                      {npc.demeanor && (
+                        <p style={{ margin: '0.25rem 0 0', color: '#475569' }}>
+                          {npc.demeanor}
+                        </p>
+                      )}
+                    </header>
+                    <p style={{ margin: 0, color: '#334155' }}>
+                      {npc.description || 'No description available.'}
+                    </p>
+                    <div style={metaLineStyle}>
+                      <span>
+                        <strong>Type:</strong> {npc.type?.name || 'Uncategorised'}
+                      </span>
+                      <span>
+                        <strong>Race:</strong> {npc.race?.name || 'Unknown'}
+                      </span>
+                      <span>
+                        <strong>Campaign links:</strong>{' '}
+                        {npc.visibility?.filter((entry) => entry.campaign_id)?.length || 0}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                      {formatVisibility(npc.visibility).map((label) => (
+                        <span key={label} style={visibilityBadgeStyle}>
+                          {label}
+                        </span>
+                      ))}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }

--- a/frontend/src/pages/WorldsPage.jsx
+++ b/frontend/src/pages/WorldsPage.jsx
@@ -1,51 +1,193 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useAuth } from '../context/AuthContext'
+import { useData } from '../context/DataContext'
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api').replace(/\/$/, '')
+const listStyle = {
+  listStyle: 'none',
+  padding: 0,
+  margin: '1.5rem 0 0',
+  display: 'grid',
+  gap: '1rem',
+}
+
+const worldCardStyle = (isActive) => ({
+  border: `1px solid ${isActive ? '#2563eb' : '#e2e8f0'}`,
+  borderRadius: '12px',
+  padding: '1rem 1.25rem',
+  backgroundColor: isActive ? '#eff6ff' : '#ffffff',
+  boxShadow: '0 10px 18px rgba(15, 23, 42, 0.08)',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+})
+
+const badgeStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  padding: '0.25rem 0.65rem',
+  borderRadius: '9999px',
+  backgroundColor: '#1e293b',
+  color: '#f8fafc',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+}
 
 export default function WorldsPage() {
-  const { currentUser, token } = useAuth()
-  const [worlds, setWorlds] = useState([])
-  const apiUrl = useMemo(() => `${API_BASE_URL}/worlds`, [])
+  const { currentUser } = useAuth()
+  const {
+    worlds,
+    worldsLoading,
+    worldsError,
+    activeWorldId,
+    setActiveWorldId,
+    refreshWorlds,
+  } = useData()
 
-  useEffect(() => {
-    async function loadWorlds() {
-      try {
-        const res = await fetch(apiUrl, {
-          headers: token
-            ? {
-                Authorization: `Bearer ${token}`,
-              }
-            : undefined,
-        })
-        if (!res.ok) {
-          throw new Error(`Request failed with status ${res.status}`)
-        }
-        const data = await res.json()
-        if (data.success) setWorlds(data.data)
-      } catch (err) {
-        console.error('Failed to load worlds', err)
-      }
-    }
-    if (token) {
-      loadWorlds()
-    }
-  }, [apiUrl, token])
+  const activeWorld = useMemo(
+    () => worlds.find((world) => world.id === activeWorldId) ?? null,
+    [activeWorldId, worlds],
+  )
+
+  const handleWorldChange = (event) => {
+    setActiveWorldId(event.target.value || null)
+  }
+
+  const handleRefresh = () => {
+    refreshWorlds()
+  }
 
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Worlds</h1>
-      {worlds.length === 0 && <p>No worlds found.</p>}
-      <ul>
-        {worlds.map((w) => (
-          <li key={w.id} className="border-b py-1">
-            {w.name}
-          </li>
-        ))}
-      </ul>
-      <p className="mt-6 text-sm text-gray-600">
-        Logged in as: {currentUser?.name} ({currentUser?.roleNames?.join(', ')})
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>Worlds</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Review the shared worlds available to your campaigns and choose which one
+            to explore across the NPC, location, and character directories.
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.75rem',
+            alignItems: 'center',
+          }}
+        >
+          {worlds.length > 1 && (
+            <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+              <span style={{ fontWeight: 600, color: '#1f2937' }}>Active world context</span>
+              <select
+                value={activeWorldId ?? ''}
+                onChange={handleWorldChange}
+                style={{
+                  marginTop: '0.35rem',
+                  borderRadius: '0.75rem',
+                  border: '1px solid #cbd5f5',
+                  padding: '0.45rem 0.75rem',
+                  minWidth: '12rem',
+                  backgroundColor: '#fff',
+                }}
+              >
+                {worlds.map((world) => (
+                  <option key={world.id} value={world.id}>
+                    {world.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            type="button"
+            onClick={handleRefresh}
+            style={{
+              border: '1px solid #2563eb',
+              color: '#1d4ed8',
+              background: '#fff',
+              borderRadius: '9999px',
+              padding: '0.45rem 1.25rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Refresh worlds
+          </button>
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {worldsLoading && <p>Loading worlds…</p>}
+        {!worldsLoading && worldsError && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load worlds: {worldsError.message || 'Unknown error'}
+          </p>
+        )}
+        {!worldsLoading && !worldsError && worlds.length === 0 && (
+          <p>No worlds available for your account yet.</p>
+        )}
+
+        {!worldsLoading && !worldsError && worlds.length > 0 && (
+          <ul style={listStyle}>
+            {worlds.map((world) => {
+              const isActive = world.id === activeWorldId
+              const campaignCount = Array.isArray(world.campaigns)
+                ? world.campaigns.length
+                : 0
+              return (
+                <li key={world.id} style={worldCardStyle(isActive)}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      gap: '1rem',
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    <div>
+                      <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{world.name}</h2>
+                      {world.description && (
+                        <p style={{ margin: '0.5rem 0 0', color: '#475569' }}>
+                          {world.description}
+                        </p>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                      {isActive && (
+                        <span style={badgeStyle}>
+                          <span aria-hidden>⭐</span>
+                          Active context
+                        </span>
+                      )}
+                      <span style={{ fontSize: '0.875rem', color: '#1f2937' }}>
+                        {campaignCount} campaign{campaignCount === 1 ? '' : 's'} linked
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      {activeWorld && (
+        <section style={{ marginTop: '2rem' }}>
+          <h2 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+            Active world summary
+          </h2>
+          <p style={{ margin: 0, color: '#475569' }}>
+            {activeWorld.description
+              ? activeWorld.description
+              : 'This world does not have a description yet.'}
+          </p>
+        </section>
+      )}
+
+      <p style={{ marginTop: '2.5rem', fontSize: '0.875rem', color: '#64748b' }}>
+        Logged in as {currentUser?.name}{' '}
+        {currentUser?.roleNames?.length
+          ? `(${currentUser.roleNames.join(', ')})`
+          : ''}
       </p>
-    </div>
+    </section>
   )
 }

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -1,0 +1,102 @@
+import { useCallback, useMemo } from 'react'
+import { useAuth } from '../context/AuthContext'
+
+const normalizeBaseUrl = (value) => {
+  if (!value) return ''
+  return value.endsWith('/') ? value.slice(0, -1) : value
+}
+
+const API_BASE_URL =
+  normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL) || 'http://localhost:3000/api'
+
+const resolveUrl = (path) => {
+  if (!path) return API_BASE_URL
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path
+  }
+  return `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+const applyContextHeaders = (headers, context = {}) => {
+  if (!context || typeof context !== 'object') return
+  if (context.worldId) headers.set('X-Active-World', context.worldId)
+  if (context.campaignId) headers.set('X-Active-Campaign', context.campaignId)
+  if (context.characterId) headers.set('X-Active-Character', context.characterId)
+}
+
+const parsePayload = async (response) => {
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) {
+    return null
+  }
+
+  try {
+    return await response.json()
+  } catch (error) {
+    console.warn('Failed to parse response body', error)
+    return null
+  }
+}
+
+export function useApiClient() {
+  const { token } = useAuth()
+
+  const request = useCallback(
+    async (path, options = {}) => {
+      const {
+        method = 'GET',
+        headers: providedHeaders,
+        body,
+        context,
+        ...rest
+      } = options
+
+      const url = resolveUrl(path)
+      const headers = new Headers(providedHeaders || {})
+
+      if (token && !headers.has('Authorization')) {
+        headers.set('Authorization', `Bearer ${token}`)
+      }
+
+      applyContextHeaders(headers, context)
+
+      const response = await fetch(url, {
+        method,
+        body,
+        headers,
+        ...rest,
+      })
+
+      const payload = await parsePayload(response)
+
+      if (!response.ok || payload?.success === false) {
+        const error = new Error(
+          payload?.message || `Request failed with status ${response.status}`,
+        )
+        error.status = response.status
+        error.payload = payload
+        throw error
+      }
+
+      if (payload && typeof payload === 'object') {
+        if ('data' in payload) {
+          return payload.data
+        }
+        return payload
+      }
+
+      return payload
+    },
+    [token],
+  )
+
+  return useMemo(
+    () => ({
+      request,
+      get: (path, options = {}) => request(path, { ...options, method: 'GET' }),
+    }),
+    [request],
+  )
+}
+
+export { API_BASE_URL }


### PR DESCRIPTION
## Summary
- add a reusable API client that injects auth and visibility context headers for backend requests
- hydrate the shared data context with world listings and expose selection/refresh helpers
- hook up the Worlds, Locations, NPC, and Characters pages to real API data with loading and error states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e650b953ac832eb181f63a5d6b892e