### PR TITLE
Restore context selectors and admin listings

### DIFF
--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -23,7 +23,17 @@ export default function Header({
   onRequestCollapseToggle,
 }) {
   const { currentUser, logout } = useAuth()
-  const { campaigns = [], characters = [] } = useData()
+  const {
+    worlds = [],
+    activeWorldId,
+    setActiveWorldId,
+    campaigns = [],
+    activeCampaignId,
+    setActiveCampaignId,
+    characters = [],
+    activeCharacterId,
+    setActiveCharacterId,
+  } = useData()
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const menuRef = useRef(null)
 
@@ -66,6 +76,13 @@ export default function Header({
 
   const collapseLabel = isSidebarCollapsed ? 'Expand menu' : 'Collapse menu'
   const collapseIcon = isSidebarCollapsed ? '⤢' : '⤡'
+  const contextSelectStyle = {
+    backgroundColor: '#1f2937',
+    color: '#f8fafc',
+    borderRadius: '0.65rem',
+    border: '1px solid rgba(148, 163, 184, 0.45)',
+    padding: '0.35rem 0.75rem',
+  }
 
   return (
     <header className="app-header">
@@ -107,13 +124,55 @@ export default function Header({
           )}
 
           <div className="context-switchers" aria-live="polite">
-            <div className="context-select">
-              <span>Campaigns</span>
-              <strong>{campaigns.length}</strong>
-            </div>
-            <div className="context-select">
-              <span>Characters</span>
-              <strong>{characters.length}</strong>
+            {worlds.length > 0 && (
+              <select
+                value={activeWorldId || ''}
+                onChange={(event) => setActiveWorldId(event.target.value || null)}
+                className="bg-gray-700 text-white rounded p-1"
+                style={contextSelectStyle}
+                aria-label="Select world context"
+              >
+                <option value="">Select World</option>
+                {worlds.map((world) => (
+                  <option key={world.id} value={world.id}>
+                    {world.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            <div className="flex space-x-2 items-center">
+              {campaigns.length > 0 && (
+                <select
+                  value={activeCampaignId || ''}
+                  onChange={(e) => setActiveCampaignId(e.target.value || null)}
+                  className="bg-gray-700 text-white rounded p-1"
+                  style={contextSelectStyle}
+                  aria-label="Select campaign context"
+                >
+                  <option value="">Select Campaign</option>
+                  {campaigns.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {characters.length > 0 && (
+                <select
+                  value={activeCharacterId || ''}
+                  onChange={(e) => setActiveCharacterId(e.target.value || null)}
+                  className="bg-gray-700 text-white rounded p-1"
+                  style={contextSelectStyle}
+                  aria-label="Select character context"
+                >
+                  <option value="">Select Character</option>
+                  {characters.map((ch) => (
+                    <option key={ch.id} value={ch.id}>
+                      {ch.name}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
           </div>
 

--- a/frontend/src/pages/CampaignsPage.jsx
+++ b/frontend/src/pages/CampaignsPage.jsx
@@ -1,7 +1,260 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
+
+const listStyle = {
+  display: 'grid',
+  gap: '1rem',
+  marginTop: '1.5rem',
+}
+
+const campaignCardStyle = (isActive) => ({
+  border: `1px solid ${isActive ? '#16a34a' : '#e2e8f0'}`,
+  borderRadius: '14px',
+  padding: '1.1rem 1.3rem',
+  backgroundColor: isActive ? '#dcfce7' : '#ffffff',
+  boxShadow: '0 12px 20px rgba(15, 23, 42, 0.08)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+})
+
+const selectStyle = {
+  borderRadius: '0.75rem',
+  border: '1px solid #cbd5f5',
+  padding: '0.45rem 0.75rem',
+  minWidth: '12rem',
+  backgroundColor: '#fff',
+}
+
+const badgeStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  padding: '0.25rem 0.65rem',
+  borderRadius: '9999px',
+  backgroundColor: '#0f172a',
+  color: '#f8fafc',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+}
+
 export default function CampaignsPage() {
+  const api = useApiClient()
+  const {
+    worlds,
+    worldsLoading,
+    worldsError,
+    activeWorldId,
+    setActiveWorldId,
+    campaigns,
+    activeCampaignId,
+    setActiveCampaignId,
+    activeCharacterId,
+  } = useData()
+
+  const [campaignDetails, setCampaignDetails] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!activeWorldId) {
+      setCampaignDetails([])
+      setLoading(false)
+      setError(null)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/campaigns', {
+        signal: controller.signal,
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        const list = Array.isArray(data) ? data : []
+        const scoped = list.filter((entry) => {
+          if (!activeWorldId) return true
+          const worldId = entry.world_id || entry.world?.id
+          return !worldId || worldId === activeWorldId
+        })
+        setCampaignDetails(scoped)
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load campaigns', err)
+        setCampaignDetails([])
+        setError(err)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
+
+  const activeWorld = useMemo(
+    () => worlds.find((world) => world.id === activeWorldId) ?? null,
+    [activeWorldId, worlds],
+  )
+
+  const handleWorldChange = (event) => {
+    setActiveWorldId(event.target.value || null)
+  }
+
+  const handleCampaignChange = (event) => {
+    setActiveCampaignId(event.target.value || null)
+  }
+
   return (
-    <div>
-      <h1>Campaigns</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>Campaigns</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Select a world to review its campaigns, switch the active context, and see
+            who is leading each adventure.
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.75rem',
+            alignItems: 'center',
+          }}
+        >
+          <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+            <span style={{ fontWeight: 600, color: '#1f2937' }}>World context</span>
+            <select
+              value={activeWorldId ?? ''}
+              onChange={handleWorldChange}
+              disabled={worldsLoading || !!worldsError}
+              style={selectStyle}
+            >
+              <option value="">Select a world</option>
+              {worlds.map((world) => (
+                <option key={world.id} value={world.id}>
+                  {world.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {campaigns.length > 0 && (
+            <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+              <span style={{ fontWeight: 600, color: '#1f2937' }}>Active campaign</span>
+              <select
+                value={activeCampaignId ?? ''}
+                onChange={handleCampaignChange}
+                style={selectStyle}
+              >
+                <option value="">Select a campaign</option>
+                {campaigns.map((campaign) => (
+                  <option key={campaign.id} value={campaign.id}>
+                    {campaign.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {(worldsLoading || loading) && <p>Loading campaigns…</p>}
+        {!loading && !worldsLoading && (error || worldsError) && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load campaigns: {worldsError?.message || error?.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !worldsLoading && !error && !worldsError && (
+          <>
+            {campaignDetails.length === 0 ? (
+              <div
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '12px',
+                  padding: '1.25rem 1.5rem',
+                  backgroundColor: '#f8fafc',
+                }}
+              >
+                <p style={{ margin: 0 }}>
+                  No campaigns were returned for this world. Ensure you have visibility or
+                  create a new campaign to get started.
+                </p>
+              </div>
+            ) : (
+              <ul style={listStyle}>
+                {campaignDetails.map((campaign) => {
+                  const isActive = campaign.id === activeCampaignId
+                  const dm = campaign.roles?.find((role) => role.name === 'Dungeon Master')
+                  const owner = campaign.creator?.name || campaign.creator?.username || 'Unknown'
+                  const participantCount = campaign.characters?.length ?? 0
+
+                  return (
+                    <li key={campaign.id} style={campaignCardStyle(isActive)}>
+                      <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+                        <div>
+                          <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{campaign.name}</h2>
+                          {campaign.description && (
+                            <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>{campaign.description}</p>
+                          )}
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.4rem' }}>
+                          {isActive ? (
+                            <span style={badgeStyle}>
+                              <span aria-hidden>🎯</span>
+                              Active
+                            </span>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => setActiveCampaignId(campaign.id)}
+                              style={{
+                                border: '1px solid #16a34a',
+                                color: '#15803d',
+                                background: '#f0fdf4',
+                                borderRadius: '9999px',
+                                padding: '0.35rem 1rem',
+                                fontWeight: 600,
+                                cursor: 'pointer',
+                              }}
+                            >
+                              Set active
+                            </button>
+                          )}
+                          <span style={{ fontSize: '0.85rem', color: '#1f2937' }}>
+                            {participantCount} participant{participantCount === 1 ? '' : 's'}
+                          </span>
+                        </div>
+                      </header>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', fontSize: '0.9rem', color: '#1f2937' }}>
+                        <span>
+                          <strong>World:</strong> {campaign.world?.name || activeWorld?.name || 'Unassigned'}
+                        </span>
+                        <span>
+                          <strong>DM:</strong> {dm?.users?.[0]?.username || owner}
+                        </span>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }

--- a/frontend/src/pages/CharactersPage.jsx
+++ b/frontend/src/pages/CharactersPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
 
 const tableStyle = {
   width: '100%',
@@ -30,17 +31,32 @@ const cellStyle = {
 
 export default function CharactersPage() {
   const api = useApiClient()
+  const { activeWorldId, activeCampaignId, activeCharacterId } = useData()
   const [characters, setCharacters] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
   useEffect(() => {
+    if (!activeWorldId) {
+      setCharacters([])
+      setLoading(false)
+      setError(null)
+      return undefined
+    }
+
     const controller = new AbortController()
     setLoading(true)
     setError(null)
 
     api
-      .get('/characters', { signal: controller.signal })
+      .get('/characters', {
+        signal: controller.signal,
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
+      })
       .then((data) => {
         if (controller.signal.aborted) return
         setCharacters(Array.isArray(data) ? data : [])
@@ -58,7 +74,7 @@ export default function CharactersPage() {
       })
 
     return () => controller.abort()
-  }, [api])
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
 
   return (
     <section>

--- a/frontend/src/pages/LocationsAtlas.jsx
+++ b/frontend/src/pages/LocationsAtlas.jsx
@@ -75,6 +75,8 @@ export default function LocationsAtlas() {
     worldsError,
     activeWorldId,
     setActiveWorldId,
+    activeCampaignId,
+    activeCharacterId,
   } = useData()
 
   const [locations, setLocations] = useState([])
@@ -84,6 +86,8 @@ export default function LocationsAtlas() {
   useEffect(() => {
     if (!activeWorldId) {
       setLocations([])
+      setLoading(false)
+      setError(null)
       return
     }
 
@@ -93,7 +97,11 @@ export default function LocationsAtlas() {
 
     api
       .get('/locations', {
-        context: { worldId: activeWorldId },
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
         signal: controller.signal,
       })
       .then((data) => {
@@ -113,7 +121,7 @@ export default function LocationsAtlas() {
       })
 
     return () => controller.abort()
-  }, [api, activeWorldId])
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
 
   const activeWorldName = useMemo(() => {
     if (!activeWorldId) return null

--- a/frontend/src/pages/NpcDirectory.jsx
+++ b/frontend/src/pages/NpcDirectory.jsx
@@ -80,6 +80,8 @@ export default function NpcDirectory() {
     worldsError,
     activeWorldId,
     setActiveWorldId,
+    activeCampaignId,
+    activeCharacterId,
   } = useData()
 
   const [npcs, setNpcs] = useState([])
@@ -89,6 +91,8 @@ export default function NpcDirectory() {
   useEffect(() => {
     if (!activeWorldId) {
       setNpcs([])
+      setLoading(false)
+      setError(null)
       return
     }
 
@@ -98,7 +102,11 @@ export default function NpcDirectory() {
 
     api
       .get('/npcs', {
-        context: { worldId: activeWorldId },
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
         signal: controller.signal,
       })
       .then((data) => {
@@ -118,7 +126,7 @@ export default function NpcDirectory() {
       })
 
     return () => controller.abort()
-  }, [api, activeWorldId])
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
 
   const activeWorldName = useMemo(() => {
     if (!activeWorldId) return null

--- a/frontend/src/pages/OrganisationsLedger.jsx
+++ b/frontend/src/pages/OrganisationsLedger.jsx
@@ -1,7 +1,247 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
+
+const gridStyle = {
+  display: 'grid',
+  gap: '1rem',
+  marginTop: '1.5rem',
+}
+
+const organisationCardStyle = {
+  backgroundColor: '#ffffff',
+  borderRadius: '14px',
+  border: '1px solid #e2e8f0',
+  padding: '1.25rem 1.4rem',
+  boxShadow: '0 12px 22px rgba(15, 23, 42, 0.08)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.65rem',
+}
+
+const selectStyle = {
+  borderRadius: '0.75rem',
+  border: '1px solid #cbd5f5',
+  padding: '0.45rem 0.75rem',
+  minWidth: '12rem',
+  backgroundColor: '#fff',
+}
+
+const tagStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  padding: '0.25rem 0.65rem',
+  borderRadius: '9999px',
+  backgroundColor: '#eff6ff',
+  color: '#1d4ed8',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+}
+
+const formatVisibility = (entries = []) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return ['Public']
+  }
+
+  const labels = entries.map((entry) => {
+    if (entry.campaign?.name) {
+      return `Campaign: ${entry.campaign.name}`
+    }
+    if (entry.player?.username) {
+      return `Player: ${entry.player.username}`
+    }
+    return 'Public'
+  })
+
+  return [...new Set(labels)]
+}
+
 export default function OrganisationsLedger() {
+  const api = useApiClient()
+  const {
+    worlds,
+    worldsLoading,
+    worldsError,
+    activeWorldId,
+    setActiveWorldId,
+    activeCampaignId,
+    activeCharacterId,
+  } = useData()
+
+  const [organisations, setOrganisations] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!activeWorldId) {
+      setOrganisations([])
+      setLoading(false)
+      setError(null)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/organisations', {
+        signal: controller.signal,
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        const list = Array.isArray(data) ? data : []
+        const scoped = list.filter((organisation) => {
+          if (!activeWorldId) return true
+          const worldId = organisation.world_id || organisation.world?.id
+          return !worldId || worldId === activeWorldId
+        })
+        setOrganisations(scoped)
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load organisations', err)
+        setOrganisations([])
+        setError(err)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
+
+  const activeWorld = useMemo(
+    () => worlds.find((world) => world.id === activeWorldId) ?? null,
+    [activeWorldId, worlds],
+  )
+
+  const handleWorldChange = (event) => {
+    setActiveWorldId(event.target.value || null)
+  }
+
   return (
-    <div>
-      <h1>Organisations</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>Organisations</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Track the factions and guilds available to the active world and review who can
+            see them.
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.75rem',
+            alignItems: 'center',
+          }}
+        >
+          <label style={{ display: 'flex', flexDirection: 'column', fontSize: '0.875rem' }}>
+            <span style={{ fontWeight: 600, color: '#1f2937' }}>World context</span>
+            <select
+              value={activeWorldId ?? ''}
+              onChange={handleWorldChange}
+              disabled={worldsLoading || !!worldsError}
+              style={selectStyle}
+            >
+              <option value="">Select a world</option>
+              {worlds.map((world) => (
+                <option key={world.id} value={world.id}>
+                  {world.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {activeWorld && (
+            <span style={{ fontSize: '0.9rem', color: '#1f2937' }}>
+              Showing organisations for <strong>{activeWorld.name}</strong>
+            </span>
+          )}
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {(worldsLoading || loading) && <p>Loading organisations…</p>}
+        {!loading && !worldsLoading && (error || worldsError) && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load organisations: {worldsError?.message || error?.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !worldsLoading && !error && !worldsError && (
+          <>
+            {organisations.length === 0 ? (
+              <div
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '12px',
+                  padding: '1.25rem 1.5rem',
+                  backgroundColor: '#f8fafc',
+                }}
+              >
+                <p style={{ margin: 0 }}>
+                  No organisations were returned for this world. Adjust your context or
+                  visibility rules to see more.
+                </p>
+              </div>
+            ) : (
+              <div style={gridStyle}>
+                {organisations.map((organisation) => {
+                  const visibilityLabels = formatVisibility(organisation.visibility)
+                  const locations = organisation.locations || []
+
+                  return (
+                    <article key={organisation.id} style={organisationCardStyle}>
+                      <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+                        <div>
+                          <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{organisation.name}</h2>
+                          {organisation.motto && (
+                            <p style={{ margin: '0.35rem 0 0', color: '#2563eb', fontStyle: 'italic' }}>
+                              “{organisation.motto}”
+                            </p>
+                          )}
+                        </div>
+                        {organisation.type?.name && (
+                          <span style={tagStyle}>
+                            <span aria-hidden>🏷️</span>
+                            {organisation.type.name}
+                          </span>
+                        )}
+                      </header>
+                      {organisation.description && (
+                        <p style={{ margin: 0, color: '#475569' }}>{organisation.description}</p>
+                      )}
+                      {locations.length > 0 && (
+                        <div style={{ fontSize: '0.9rem', color: '#1f2937' }}>
+                          <strong>Locations:</strong> {locations.map((loc) => loc.name).join(', ')}
+                        </div>
+                      )}
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                        {visibilityLabels.map((label) => (
+                          <span key={label} style={{ ...tagStyle, backgroundColor: '#ede9fe', color: '#5b21b6' }}>
+                            <span aria-hidden>👁️</span>
+                            {label}
+                          </span>
+                        ))}
+                      </div>
+                    </article>
+                  )
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }

--- a/frontend/src/pages/PlatformAdmin.jsx
+++ b/frontend/src/pages/PlatformAdmin.jsx
@@ -1,7 +1,107 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+
 export default function PlatformAdmin() {
+  const api = useApiClient()
+  const [users, setUsers] = useState([])
+  const [campaigns, setCampaigns] = useState([])
+  const [locationTypes, setLocationTypes] = useState([])
+  const [userError, setUserError] = useState(null)
+  const [campaignError, setCampaignError] = useState(null)
+  const [locationTypeError, setLocationTypeError] = useState(null)
+
+  const loadUsers = useCallback(async () => {
+    try {
+      const data = await api.get('/users')
+      setUsers(Array.isArray(data) ? data : [])
+      setUserError(null)
+    } catch (error) {
+      console.error('Failed to load users', error)
+      setUsers([])
+      setUserError(error)
+    }
+  }, [api])
+
+  const loadCampaigns = useCallback(async () => {
+    try {
+      const data = await api.get('/campaigns')
+      setCampaigns(Array.isArray(data) ? data : [])
+      setCampaignError(null)
+    } catch (error) {
+      console.error('Failed to load campaigns', error)
+      setCampaigns([])
+      setCampaignError(error)
+    }
+  }, [api])
+
+  const loadLocationTypes = useCallback(async () => {
+    try {
+      const data = await api.get('/locations/types')
+      setLocationTypes(Array.isArray(data) ? data : [])
+      setLocationTypeError(null)
+    } catch (error) {
+      console.error('Failed to load location types', error)
+      setLocationTypes([])
+      setLocationTypeError(error)
+    }
+  }, [api])
+
+  useEffect(() => {
+    loadUsers()
+    loadCampaigns()
+    loadLocationTypes()
+  }, [loadUsers, loadCampaigns, loadLocationTypes])
+
   return (
-    <div>
-      <h1>Admin</h1>
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Platform Administration</h1>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Users</h2>
+        {userError && (
+          <p className="text-red-300 mb-2">
+            Failed to load users: {userError.message || 'Unknown error'}
+          </p>
+        )}
+        <ul className="space-y-1">
+          {users.map((user) => (
+            <li key={user.id}>
+              {user.username} ({user.roles?.map((role) => role.name || role).join(', ') || 'No roles'}) —{' '}
+              {user.active ? 'Active' : 'Inactive'}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Campaigns</h2>
+        {campaignError && (
+          <p className="text-red-300 mb-2">
+            Failed to load campaigns: {campaignError.message || 'Unknown error'}
+          </p>
+        )}
+        <ul className="space-y-1">
+          {campaigns.map((campaign) => (
+            <li key={campaign.id}>
+              {campaign.name} — World: {campaign.world?.name || campaign.world_id || 'Unassigned'}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Location Types</h2>
+        {locationTypeError && (
+          <p className="text-red-300 mb-2">
+            Failed to load location types: {locationTypeError.message || 'Unknown error'}
+          </p>
+        )}
+        <ul className="space-y-1">
+          {locationTypes.map((type) => (
+            <li key={type.id}>{type.name}</li>
+          ))}
+        </ul>
+      </section>
     </div>
   )
 }

--- a/frontend/src/pages/RaceLibrary.jsx
+++ b/frontend/src/pages/RaceLibrary.jsx
@@ -1,7 +1,122 @@
+import { useEffect, useState } from 'react'
+import { useApiClient } from '../utils/apiClient'
+import { useData } from '../context/DataContext'
+
+const listStyle = {
+  display: 'grid',
+  gap: '1rem',
+  marginTop: '1.5rem',
+}
+
+const raceCardStyle = {
+  backgroundColor: '#ffffff',
+  borderRadius: '14px',
+  border: '1px solid #e2e8f0',
+  padding: '1.25rem 1.4rem',
+  boxShadow: '0 12px 22px rgba(15, 23, 42, 0.08)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+}
+
 export default function RaceLibrary() {
+  const api = useApiClient()
+  const { activeWorldId, activeCampaignId, activeCharacterId } = useData()
+  const [races, setRaces] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!activeWorldId) {
+      setRaces([])
+      setLoading(false)
+      setError(null)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    api
+      .get('/races', {
+        signal: controller.signal,
+        context: {
+          worldId: activeWorldId,
+          campaignId: activeCampaignId,
+          characterId: activeCharacterId,
+        },
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setRaces(Array.isArray(data) ? data : [])
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        console.error('Failed to load races', err)
+        setRaces([])
+        setError(err)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      })
+
+    return () => controller.abort()
+  }, [api, activeWorldId, activeCampaignId, activeCharacterId])
+
   return (
-    <div>
-      <h1>Races</h1>
-    </div>
+    <section>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.75rem', fontWeight: 700, margin: 0 }}>Race library</h1>
+          <p style={{ margin: '0.4rem 0 0', color: '#475569' }}>
+            Reference the player races available in the current world context. The list
+            reflects any visibility restrictions applied by the Dungeon Master.
+          </p>
+        </div>
+      </header>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {loading && <p>Loading races…</p>}
+        {!loading && error && (
+          <p style={{ color: '#b91c1c' }}>
+            Unable to load races: {error.message || 'Unknown error'}
+          </p>
+        )}
+
+        {!loading && !error && (
+          <>
+            {races.length === 0 ? (
+              <div
+                style={{
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '12px',
+                  padding: '1.25rem 1.5rem',
+                  backgroundColor: '#f8fafc',
+                }}
+              >
+                <p style={{ margin: 0 }}>
+                  No races are visible in this world. Check your campaign permissions or
+                  ask a world admin to add some entries.
+                </p>
+              </div>
+            ) : (
+              <div style={listStyle}>
+                {races.map((race) => (
+                  <article key={race.id} style={raceCardStyle}>
+                    <h2 style={{ margin: 0, fontSize: '1.25rem' }}>{race.name}</h2>
+                    {race.description && (
+                      <p style={{ margin: 0, color: '#475569' }}>{race.description}</p>
+                    )}
+                  </article>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- extend the shared data context to track active campaign and character selections and hydrate dependent lists
- restore the header context switcher with world, campaign, and character dropdowns and update data pages to pass visibility context to API calls
- rebuild campaign, organisation, race, and platform admin pages to show context-aware data pulled from the API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65a535624832ebe1e55198dfe928f